### PR TITLE
Add changelog, contributing statement, and authors file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,7 @@
+# Project Lead:
+
+    - Vanessa Sochat <vsochat@stanford.edu>
+
+# Contributors:
+
+    - Brian Kolowitz <bkolowitz@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# CHANGELOG
+
+This is a manually generated log to track changes to the repository for each release. 
+Each section should include general headers such as **Implemented enhancements** 
+and **Merged pull requests**. All closed issued and bug fixes should be 
+represented by the pull requests that fixed them. This log originated with Singularity 2.4
+and changes prior to that are (unfortunately) done retrospectively. Critical items to know are:
+
+ - renamed commands
+ - deprecated / removed commands
+ - changed defaults
+ - backward incompatible changes (recipe file format? image file format?)
+ - migration guidance (how to convert images?)
+ - changed behaviour (recipe sections work differently)
+
+## [vxx](https://github.com/pydicom/deid/tree/development) (development)
+
+**additions**
+ - addition of this CHANGELOG and an AUTHORS and CONTRIBUTING file to properly open source the project.
+
+## [0.1.1](https://pypi.python.org/packages/28/26/ee80e7f1c3f65fae1c901497bb2388701158f0c96e0d633ab301abeaa478/deid-0.1.1.tar.gz#md5=39df7efb03e5d3b63308016742062a43) (0.1.1)
+
+**bug fix**
+ - when the user specifies a deid recipe, instead of adding it to a base template we honor the choice and don't append a base.
+**creation**
+ - this is the initial creation of deid, including recipes for cleaning of image headers and flagging of potential phi in pixels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,10 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [vxx](https://github.com/pydicom/deid/tree/development) (development)
 
-**additions**
- - addition of this CHANGELOG and an AUTHORS and CONTRIBUTING file to properly open source the project.
-
 ## [0.1.1](https://pypi.python.org/packages/28/26/ee80e7f1c3f65fae1c901497bb2388701158f0c96e0d633ab301abeaa478/deid-0.1.1.tar.gz#md5=39df7efb03e5d3b63308016742062a43) (0.1.1)
 
+**additions**
+ - addition of this CHANGELOG and an AUTHORS and CONTRIBUTING file to properly open source the project.
 **bug fix**
  - when the user specifies a deid recipe, instead of adding it to a base template we honor the choice and don't append a base.
 **creation**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing
+
+When contributing to deid, it is important to properly communicate the
+gist of the contribution. If it is a simple code or editorial fix, simply
+explaining this within the GitHub Pull Request (PR) will suffice. But if this
+is a larger fix or enhancement, it should be first discussed with the project
+ developers first.
+
+Please note we have a code of conduct, described below. Please follow it in
+all your interactions with the project members and users.
+
+This code is licensed under the MIT [LICENSE](LICENSE).
+
+## Pull Request Process
+
+1. Bug fix PRs should be sent to both the master and development branches.
+   Feature enhancements should only be submitted against the development
+   branch.
+2. Follow the existing code style precedent. This does not need to be strictly
+   defined as there are many thousands of lines of examples. Note the lack
+   of tabs anywhere in the project, parentheses and spacing, documentation
+   style, source code layout, variable scoping, and follow the project's
+   standards.
+3. Test your PR locally, and provide the steps necessary to test for the
+   reviewers.
+4. The project's default copyright and header have been included in any new
+   source files.
+5. All (major) changes to deid must be documented in
+   [docs](docs). If your PR changes a core functionality, please 
+   include clear description of the changes in your PR so that the docs 
+   can be updated, or better, submit another PR to update the docs directly.
+6. If necessary, update the [README](README.md), and the [CHANGELOG](CHANGELOG.md).
+7. The pull request will be reviewed by others, and the final merge must be
+   done by the Singularity project lead, @vsoch (or approved by her).
+
+
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project leader (gmkurtzer@gmail.com). All
+complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. The project
+team is obligated to maintain confidentiality with regard to the reporter of
+an incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers, contributors and users who do not follow or enforce the
+Code of Conduct in good faith may face temporary or permanent repercussions 
+with their involvement in the project as determined by the project's leader(s).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/deid/version.py
+++ b/deid/version.py
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
This will add a changelog, authors, and contributing markdown files, and be merged into master to be tagged with version 0.1.1. @BrianKolowitz does this look okay to you? (note the email in the AUTHORS.md). We can use a different format if you have preference!  This will close #31 