### PR TITLE
Adding DeidRecipe Class (to development branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [vxx](https://github.com/pydicom/deid/tree/development) (development)
 
+**additions**
+ - addition of the DeidRecipe class to better interact with and combine deid recipe files.
+
 ## [0.1.1](https://pypi.python.org/packages/28/26/ee80e7f1c3f65fae1c901497bb2388701158f0c96e0d633ab301abeaa478/deid-0.1.1.tar.gz#md5=39df7efb03e5d3b63308016742062a43) (0.1.1)
 
 **additions**

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
 include README.md LICENSE
 recursive-include deid *
-recursive-exclude * __pycache__
-recursive-exclude * app
-recursive-exclude * *.pyc
-recursive-exclude * *.pyo
-recursive-exclude * *.orig
+global-exclude __pycache__
+prune deid/app
+prune *OLD

--- a/deid/config/__init__.py
+++ b/deid/config/__init__.py
@@ -1,10 +1,179 @@
-from .utils import (
+'''
+
+DeidRecipe
+
+Copyright (c) 2017 Vanessa Sochat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The functions below assume a configuration file called deid, although the
+user can specify a custom name.
+
+
+'''
+
+from deid.config.utils import (
     load_deid,
     get_deid,
     load_combined_deid
 )
-from .standards import (
+from deid.config.standards import (
     actions,
     sections,
     formats
 )
+
+from deid.logger import bot
+import os
+import re
+
+bot.level = 3
+
+class DeidRecipe:
+    '''
+       Create and work with a deid recipe to filter and perform operations on
+       a dicom header. Usage typically looks like:
+
+       deid = 'dicom.deid'
+       recipe = DeidRecipe(deid)
+       
+       If deid is None, the default provided by the application is used.
+
+       Parameters
+       ==========
+           deid: the deid recipe (or recipes) files to use. If more than one
+                 is provided, should be done in order of preference for load
+                 (later in the list overrides earlier loaded).
+           base: if True, load a default base (default_base) before custom
+           default_base: the default base to load if "base" is True
+    '''
+    
+    def __init__(self, deid=None, base=False, default_base='dicom'):
+
+        # If deid is None, use the default
+        if deid is None:
+            bot.warning('No specification, loading default base deid.%s' %default_base)
+            base = True
+
+        self._init_deid(deid, base=base, default_base=default_base)
+
+    def __str__(self):
+        return '[deid]'
+
+    def __repr__(self):
+        return '[deid]'
+
+    def load(self, deid):
+        '''
+           load a deid recipe into the object. If a deid configuration is
+           already defined, append to that. 
+        '''
+        deid = get_deid(deid)
+        if deid is not None:
+ 
+            # Update our list of files
+            self._files.append(deid)
+            self.files = list(set(self.files))
+
+            # Priority here goes to additional deid
+            self.deid = load_combined_deid([self.deid, deid])
+
+    def _get_section(self, name):
+        '''
+           return a section (key) in the loaded deid, if it exists
+        '''
+        section = None
+        if self.deid is not None:
+            if name in self.deid:
+                section = self.deid[name]
+        return section
+
+
+    def get_format(self):
+        '''return the format of the loaded deid, if one exists
+        '''
+        return self._get_section('format')
+
+
+    def get_filters(self, name=None):
+        '''return all filters for a deid recipe, or a set based on a name
+        '''
+        filters = self._get_section('filter')
+        if name is not None and filters is not None:
+            filters = filters[name]        
+        return filters
+
+
+    def ls_filters(self):
+        '''list names of filter groups
+        '''
+        filters = self._get_section('filter')
+        return list(filters.keys())
+
+    def get_actions(self, action=None, field=None):
+        '''get deid actions to perform on a header, or a subset based on a type
+
+        A header action is a list with the following:
+         {'action': 'REMOVE', 'field': 'AssignedLocation'},
+ 
+        Parameters
+        ==========
+        action: if not None, filter to action specified
+        field: if not None, filter to field specified
+
+        '''
+        header = self._get_section('header')
+        if header is not None:
+            if action is not None:
+                action = action.upper()
+                header = [x for x in header if x['action'].upper() == action]      
+            if field is not None:
+                field = field.upper()
+                header = [x for x in header if x['field'].upper() == field]  
+
+        return header
+
+
+    def _init_deid(self, deid=None, base=False, default_base='dicom'):
+        '''
+        initalize the recipe with one or more deids, optionally including 
+        the default. This function is called at init time. If you need to add
+        or work with already loaded configurations, use add/remove 
+    
+        Parameters
+        ==========
+            deid: the deid recipe (or recipes) files to use. If more than one
+                  is provided, should be done in order of preference for load
+                  (later in the list overrides earlier loaded).
+            default_base: load the default base before the user customizations. 
+        '''
+        if deid is None:
+            deid = []
+
+        if not isinstance(deid,list):
+            deid = [deid]
+
+        if base is True:
+            deid.append(default_base)
+
+        self._files = deid
+
+        if len(deid) == 0:
+            bot.info('You can add custom deid files with .load().')
+        self.deid = load_combined_deid(deid)

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -416,7 +416,7 @@ def add_section(config,section,section_name=None):
     return config
 
 
-def parse_action(section,line,config,section_name=None):
+def parse_action(section, line, config, section_name=None):
     '''add action will take a line from a deid config file, a config (dictionary), and
     an active section name (eg header) and add an entry to the config file to perform
     the action.
@@ -467,8 +467,7 @@ def parse_action(section,line,config,section_name=None):
 
 
 def get_deid(tag=None, exit_on_fail=True, quiet=False, load=False):
-    '''
-    get deid is intended to retrieve the full path of a deid file provided with
+    '''get deid is intended to retrieve the full path of a deid file provided with
     the software, based on a tag. For example, under deid/data if a file is called
     "deid.dicom", the tag would be "dicom". 
 

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
+from deid.config import DeidRecipe
 from deid.logger import bot
 from pydicom import read_file
 import matplotlib
@@ -58,7 +59,7 @@ class DicomCleaner():
         self.font = font
         self.cmap = 'gray'
         self.output_folder = output_folder
-        self.deid = deid
+        self.recipe = DeidRecipe(deid)
         self.results = None
         self.force = force
 
@@ -75,7 +76,9 @@ class DicomCleaner():
         '''detect will initiate the cleaner for a new dicom file.
         '''
         from deid.dicom.pixels.detect import has_burned_pixels
-        self.results = has_burned_pixels(dicom_file, deid=self.deid, force=self.force)
+        self.results = has_burned_pixels(dicom_file, 
+                                         deid=self.recipe.deid,
+                                         force=self.force)
         self.dicom_file = dicom_file
         return self.results
         
@@ -99,7 +102,7 @@ class DicomCleaner():
             bot.info('Scrubbing %s.' %self.dicom_file)
 
             # Load in dicom file, and image data
-            dicom = read_file(self.dicom_file,force=True)
+            dicom = read_file(self.dicom_file, force=True)
 
             # We will set original image to image, cleaned to clean
             self.original = dicom._get_pixel_array()
@@ -145,6 +148,7 @@ class DicomCleaner():
 
         basename = re.sub('[.]dicom|[.]dcm', '', os.path.basename(self.dicom_file))
         return "%s/cleaned-%s.%s" %(output_folder, basename, extension)
+
         
     def save_png(self, output_folder=None, image_type="cleaned", title=None):
         '''save an original or cleaned dicom as png to disk.
@@ -162,6 +166,7 @@ class DicomCleaner():
             return png_file
         else:
             bot.warning('use detect() --> clean() before saving is possible.')
+
 
     def save_dicom(self, output_folder=None, image_type="cleaned"):
         '''save a cleaned dicom to disk. We expose an option to save

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -23,19 +23,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
+from deid.config import DeidRecipe
 from deid.logger import bot
 from pydicom import read_file
 from deid.dicom.filter import apply_filter
 
-from deid.config import (
-    get_deid,
-    load_combined_deid
-)
-
 import os
 import sys
 
-def has_burned_pixels(dicom_files,force=True,deid=None):
+def has_burned_pixels(dicom_files, force=True, deid=None):
     ''' has burned pixels is an entrypoint for has_burned_pixels_multi (for 
     multiple images) or has_burned_pixels_single (for one detailed repor)
     We will use the MIRCTP criteria (see ref folder with the
@@ -45,9 +41,10 @@ def has_burned_pixels(dicom_files,force=True,deid=None):
     detailed result (for single)
     '''
     # if the user has provided a custom deid, load it
-    if deid is None:
-        deid = 'dicom'
-    deid = get_deid(deid, load=True)
+    if not isinstance(deid, DeidRecipe):
+        if deid is None:
+            deid = 'dicom'
+        deid = DeidRecipe(deid)
 
     if isinstance(dicom_files,list):
         return _has_burned_pixels_multi(dicom_files, force, deid)
@@ -55,9 +52,11 @@ def has_burned_pixels(dicom_files,force=True,deid=None):
 
 
 
-def _has_burned_pixels_multi(dicom_files,force=True,deid=None):
+def _has_burned_pixels_multi(dicom_files, force, deid):
     '''return a summary dictionary with lists of clean, and then lookups
-       for flagged images with reasons.
+       for flagged images with reasons. The deid should be a deid recipe
+       instantiated from deid.config.DeidRecipe. This function should not
+       be called directly, but should be called from has_burned_pixels
     '''
 
     # Store decisions in lookup based on filter groups
@@ -79,7 +78,7 @@ def _has_burned_pixels_multi(dicom_files,force=True,deid=None):
     return decision
 
 
-def _has_burned_pixels_single(dicom_file,force=True, deid=None):
+def _has_burned_pixels_single(dicom_file, force, deid):
 
     '''has burned pixels single will evaluate one dicom file for burned in
     pixels based on 'filter' criteria in a deid. If deid is not provided,
@@ -129,7 +128,8 @@ def _has_burned_pixels_single(dicom_file,force=True, deid=None):
     dicom_name = os.path.basename(dicom_file)
         
     # Load criteria (actions) for flagging
-    if 'filter' not in deid:
+    filters = deid.get_filters()
+    if not filters:
         bot.error('Deid provided does not have %filter, exiting.')
         sys.exit(1)
 
@@ -137,7 +137,7 @@ def _has_burned_pixels_single(dicom_file,force=True, deid=None):
     results = []
     global_flagged = False
 
-    for name,items in deid['filter'].items():
+    for name,items in filters.items():
         for item in items:
             flags = []
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This Python module is intended for basic coding of medical images, which means "
 What this module does do:
 
  - Anonymize header data based on a specific logic of replacing, blanking, removing, or some custom function (e.g., "replace field X with item Y,")
- - Pass images through a filter for quarantine based on header logic.
+ - Pass images through a filter for quarantine based on header logic, and if pixel coordinates are available, can black them out.
  - For each of the above, you can use defaults (blacklist, whitelist, graylist), or create your own customized logic.
  - provides functions for developers, and executables and containers for users.
 
@@ -16,7 +16,6 @@ For dicom data, we use [pydicom](https://www.github.com/pydicom/pydicom) and for
 
 ## Getting Started
 If you are *not* a developer, or interested in getting started with using and understanding the software, you should start out by reading our [getting-started](getting-started.md) guide.  If you are a developer and are interested in using `deid` to implement a custom pipeline, see the following sections:
-
 
 ## Dicom
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -17,6 +17,11 @@ which deid
 /home/vanessa/anaconda3/bin/deid
 ```
 
+**Note** @vsoch thinks this client could be better organized (with regard to usage and commands) please [provide feedback]
+(https://www.github.com/pydicom/deid/issues) as you test these functions! The primary use of deid by the developers group has 
+been via functions in Python, so the client might be neglected.
+
+
 ## Usage
 If you run the executable without any arguments, it will show you it's usage:
 
@@ -29,6 +34,7 @@ deid: error: the following arguments are required: --action/-a
 ```
 
 It's telling us that it wants an action, which can be one of `{get,put,all}`, where "get" corresponds to getting identifiers from a dataset, "put" corresponds to doing the replacement, and "all" means you want to do both at the same time (meaning you won't intervene between the calls to customize any of the replacement actions. Let's walk through the simplest use case, giving an action without any other arguments, which will use the default dataset provided (a subset of [dicom-cookies](https://pydicom.github.io/dicom-cookies)).
+
 
 ### Inspect
 Currently, inspect is simply going to look at header fields and try to guess if there are burned pixels in the image. I am not convinced this is robust - the filters I am using are from [MIRC CTP](https://github.com/johnperry/CTP/blob/master/source/files/scripts/BurnedInPixelsFilter.script), and seem to generally look for:

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,12 +2,12 @@
 
 A full anonymization process has three parts:
 
- - define a set of rules for de-identification (optional)
+ - define a set of rules for de-identification, we call this a [deid recipe](recipe.md) (optional)
  - [get](get.md) current fields (if you need to use them to look up replacements, etc)
  - [update](update.md) identifiers however you need for your de-identification process.
  - [put](put.md) (possibly updated) identifiers back into the data, and deidentify fully.
 
-This document will talk about the first step of this process, how you can configure rules for the software. If you are interested in the command line client for these commands (and not functions) you should see [the client](client.md).
+this document will talk about the first step of this process, how you can configure rules for the software. If you are interested in the command line client for these commands (and not functions) you should see [the client](client.md).
 
 ## Defaults
 The application does the following, by default, taking a conservative de-identification process:
@@ -252,29 +252,4 @@ REPLACE PatientID var:id
 REPLACE InstanceSOPUID var:source_id
 ```
 
-### Section pixels
-and when we have procedures (functions) to perform on data, for example, scrubbing pixels, those will be specified in a separate `%pixels` section: 
-
-```
-FORMAT dicom
-
-%header
-
-ADD PatientIdentityRemoved Yes
-REPLACE PatientID var:id
-REPLACE SOPInstanceUID var:source_id
-
-%pixels
-
-ADD clean_pixels
-```
-
-In the above example, the function `clean_pixels` would be expected to be importable from the dicom module:
-
-```
-from deid.dicom import clean_pixels
-```
-
-For more complex tasks like converting from dicom to nifti, the user is (for now) suggested to work with the formats separately, meaning a config file for the dicoms (meaning with `FORMAT dicom`) to output to a folder with nifti files, and then using a separate `deid` with `FORMAT nifti` for that folder. It could be possible to combine these into one file at some point, i need to think about it.
-
-Now that you know how configuration works, we should look at some examples for generating a basic [get](get.md), which is will get a set of fields and values from your dicom files.
+Now that you know how configuration works, you have two options. If you care about interacting with your recipe via a client, [read about that here](recipe.md). If you want to write a text file and get going with cleaning your files, you should look at some examples for generating a basic [get](get.md), which is will get a set of fields and values from your dicom files.

--- a/docs/get.md
+++ b/docs/get.md
@@ -131,11 +131,13 @@ ids['cookie-47']['1.2.276.0.7230010.3.1.4.8323329.5360.1495927170.640947']
 ```
 
 ## Save what you need
-Pretty neat! At this point, you have two options:
+Pretty neat! At this point, you have a few options:
+
+### Recipe Interaction
+If you want to do more than load in a basic recipe file (e.g., add new actions, use only a subset of groups, or any customization) then you should read about how to [work with recipes](recipes.md).
 
 ### Clean Pixels
-It's likely that the pixels in the images have burned in annotations, and we can use the header data to flag these images. Thus, before you replace identifiers, you probably want to do this. We currently don't have this implemented in production quality, but you can see progress in the [pixels](pixels.md) documentation.
-
+It's likely that the pixels in the images have burned in annotations, and we can use the header data to flag these images. Thus, before you replace identifiers, you probably want to do this. We have a DicomCleaner class that can flag images for PHI based on matching some header filter criteria, and you can [read about that here](pixels.md). 
 
 ### Update Identifiers
-It's likely that you now want to query your special de-identification API to do some replacement of the PatientID with something else, or custom parsing of the data. You can read our [update](update.md) docs for instructions on how to do this replacement.
+Once you are finished with any customization of the recipe, updating identifiers, and/or potentially flagging and quarantining images that have PHI, you should be ready to [update your images](update.md) with new fields based on the deid recipe.

--- a/docs/pixels.md
+++ b/docs/pixels.md
@@ -1,9 +1,9 @@
 # Cleaning Pixels
 
-At this point, you've possibly obtained identifiers via a [get](get.md) action, and you want to figure out which of your images have pixels burned into the data. For that, we have a [set of pixel functions](../deid/dicom/pixels.py) that mirror the functionality of MIRCTP, specifically the functions to [filter DICOM](http://mircwiki.rsna.org/index.php?title=The_CTP_DICOM_Filter) and then [Anonymize](http://mircwiki.rsna.org/index.php?title=The_CTP_DICOM_Pixel_Anonymizer). The  [DicomPixelAnonymizer.script](https://github.com/johnperry/CTP/blob/master/source/files/scripts/DicomPixelAnonymizer.script) is a rule based list of known machine and modality types, and specific locations in the pixels where annotations are commonly found. The [BurnedInPixels.script](https://github.com/johnperry/CTP/blob/master/source/files/scripts/BurnedInPixelsFilter.script) is a set of filters that, given that an image passes through them, it continues processing. If it fails, then we flag it.
+At this point, you've possibly obtained identifiers via a [get](get.md) action, and you want to figure out which of your images have pixels burned into the data. If you don't want the detalis, jump into our [example script](https://github.com/pydicom/deid/blob/master/examples/dicom/pixels/run-cleaner-client.py). Here we will walk through how this cleaner was derived, and how it works.
 
-### Flagging Burned Images
-If we look at the [BurnedInPixels.script](https://github.com/johnperry/CTP/blob/master/source/files/scripts/BurnedInPixelsFilter.script), we see the following:
+## Inspiration from CTP
+Flagging images with potentially having burned in PHI is based on a well established rule-based approach. We know a concrete list of header fields and known locations with PHI associated with fields in the header, and we can check these fields in any files and then perform cleaning if there is a match. This approach is based on the MIRCTP functions to [filter DICOM](http://mircwiki.rsna.org/index.php?title=The_CTP_DICOM_Filter) and then [Anonymize](http://mircwiki.rsna.org/index.php?title=The_CTP_DICOM_Pixel_Anonymizer). The  [DicomPixelAnonymizer.script](https://github.com/johnperry/CTP/blob/master/source/files/scripts/DicomPixelAnonymizer.script) is a rule based list of known machine and modality types, and specific locations in the pixels where annotations are commonly found. The [BurnedInPixels.script](https://github.com/johnperry/CTP/blob/master/source/files/scripts/BurnedInPixelsFilter.script) is a set of filters that, given that an image passes through them, it continues processing. If it fails, then we flag it. If we look at the script above, we see the following:
 
 ```
     # We continue processing given that:
@@ -47,29 +47,71 @@ The pixels with bounding boxes (0,0,100,20) and (480,200,32,250) should be remov
 
 I'm not entirely sure why these two are separate (as both seem to indicate a flag for an image having PHI) but likely it's because the first group (`BurnedInPixels.script`) indicates header fields that are likely to indicate annotation, but don't carry any obvious mapping to a location. We can think of both as a set of filters, some with a clear location, and others not. TLDR: the second file (`DicomPixelAnonymizer.script`) has both header fields and locations.
 
+## Deid Implementation
+We have a [set of pixel functions](../deid/dicom/pixels) that mirror the functionality of MIRCTP, and we take a similar approach of deriving the rules for this process from a [deid recipe](recipe.md). Our implementeation of a [DicomCleaner](https://github.com/pydicom/deid/blob/master/deid/dicom/pixels/clean.py#L35) generally works as follows:
 
-### Deid Representation
-For our purposes, since we just want to flag images with PHI, we don't need to distinguish fields as the MIRCTP does. Also, given that these criteria are universal (it would be unlikely that we would want to give users control to re-define what is considered PHI) we represent these criteria in the [config.json](../deid/dicom/config.json) provided in the dicom module. The filters look like this:
+1. The user initializes a [Recipe](recipe.md) to configure detecting images with PHI (and possibly cleaning). The recipe has two parts - a set of filters to run over the headers to estimate if an image has burned in pixels (a section that starts with `%filter`), and a list of header cleaning rules (`%header`).
+2. The recipe is used to categorize the images into groups based on the defined lists, or to clean the data.
+3. The user selects some subset of images to continue forward with replacement of identifiers.
+
+To jump right in to using the Dicom Cleaner, see our [example script](https://github.com/pydicom/deid/blob/master/examples/dicom/pixels/run-cleaner-client.py). We will walk through the basics here.
+
+We start by importing the class
 
 ```
-   "filter":{
-
-          "contains":[
- 
-              {"action":"FLAG","field":"ImageType","value": "SAVE"},
-              {"action":"FLAG","field":"DateOfSecondaryCapture", "value":""},
-              {"action":"FLAG","field":"SeriesDescription", "value":"SAVE"},
-              {"action":"FLAG","field":"SecondaryCaptureDeviceManufacturer", "value":""},
-              {"action":"FLAG","field":"SecondaryCaptureDeviceManufacturerModelName", "value":""},
-              {"action":"FLAG","field":"SecondaryCaptureDeviceSoftwareVersions", "value":""},
-              {"action":"FLAG","field":"BurnedInAnnotation", "value":"YES"}
-
-
-      ]
-   }
+from deid.dicom import DicomCleaner, get_files 
+from deid.data import get_dataset
 ```
-     
-The user can call a function to go through a list of images, and determine which are likely to have PHI.
 
+and grabbing a dicom file to work with
 
+```
+dicom_file = get_files(get_dataset('dicom-cookies'))[0]
+```
 
+### Client
+
+We need to instantiate a client once, and can use this client to clean one or more files.
+Note that there are various options for setting default output folders. if you don't set
+an output folder, a temporary directory is created and used.
+
+```
+client = DicomCleaner()
+client = DicomCleaner(output_folder='/home/vanessa/Desktop')
+```
+
+The basic steps we will take are the following:
+
+ - `client.detect(dicom_file)`: detect if the image potentially has burned in pixels
+ - `client.clean()`: clean the areas by writing black pixels, given that coordinates are provided in the recipe.
+ - `client.save_<format>`: save the images to a new dicom or png
+
+### Detect
+
+Detect means using the deid recipe to parse headers. You must run detect before you try to clean. If you don't:
+
+```
+client.clean()
+WARNING Use <deid.dicom.pixels.clean.DicomCleaner object at 0x7fafb70b9cf8>.detect() to find coordinates first.
+```
+
+Once you've run detect, you will get a result that includes any flags triggered:
+
+```
+client.detect(dicom_file)
+
+{'flagged': True,
+'results': [{'coordinates': [],
+  'group': 'blacklist',
+  'reason': ' ImageType missing  or ImageType empty '}]}
+```
+
+### Clean and Save
+After detection, the flags that were triggered are saved with the client, until you override with another file.
+You can now run clean, and save the images to a format that you like. Remember that even with flags, if there are no coordinates associated with the flag, no changes are done to the image.
+
+```
+client.clean()
+client.save_png()
+client.save_dicom()
+```

--- a/docs/pixels.md
+++ b/docs/pixels.md
@@ -66,7 +66,8 @@ from deid.data import get_dataset
 and grabbing a dicom file to work with
 
 ```
-dicom_file = get_files(get_dataset('dicom-cookies'))[0]
+dataset = get_dataset('dicom-cookies')
+dicom_file = list(get_files(dataset))[0]
 ```
 
 ### Client

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -159,7 +159,7 @@ import os
 
 # This will get a set of example cookie dicoms
 base = get_dataset('dicom-cookies')
-dicom_files = get_files(base)
+dicom_files = list(get_files(base))
 ```
 
 Here is the function to get identifiers

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -1,0 +1,262 @@
+# The Deid Recipe
+
+As we've discussed, the basic actions of using header filters to flag images, and performing actions on headers (for replacement), are controlled by a text file called a deid recipe. If you want a reminder about how to write this text file, [read here](config.md), and we hope to at some point have an interactive way as well (let us know your feedback!). The basic gist of the file is that we have sections. In the `%header` section we have a list of actions to take on header fields, and in each `filter` section we have lists of criteria to check image headers against, and given a match, we flag the image as belonging to the group.
+
+In this small tutorial, we will walk through the basic steps of loading a recipe, interacting with it, and then using it to replace identifiers. If you want to jump in, then go straight to the [script](https://github.com/pydicom/deid/blob/master/examples/dicom/deid-dicom-example.py) that describes this example.
+
+## Create a DeidRecipe
+We will start with how to work with a [DeidRecipe](https://github.com/pydicom/deid/blob/master/deid/config/__init__.py) object. If you aren't interested in this use case or just want to use a provided deid recipe file, continue to the next section.
+
+We start by importing the class, and instantiating it.
+
+```
+from deid.config import DeidRecipe
+recipe = DeidRecipe()
+WARNING No specification, loading default base deid.dicom
+```
+
+Since we didn't load a custom deid recipe text file, we get a default warning message that
+a default is being use. That default is a [dicom base](https://github.com/pydicom/deid/blob/master/deid/data/deid.dicom) provided by the library. If you want to see the raw data structure that is loaded, look here:
+
+```
+recipe.deid
+```
+
+You can also double check the recipe format. We currently only support dicom, but this could in the future be other image formats.
+
+
+```
+recipe.get_format()
+# dicom
+```
+
+Note that validation of this structure happens at load time. If something is incorrecly labeled or formatted, you will get an error message and it will fail to load. You can also provide your own deid recipe file, and in doing so, you won't load the default. Here is one from our examples folder
+
+
+```
+wget https://raw.githubusercontent.com/pydicom/deid/master/examples/deid/deid.dicom
+```
+
+and in Python...
+
+```
+deid_file = os.path.abspath('deid.dicom')
+recipe = DeidRecipe(deid=deid_file)
+```
+
+You can also choose to load the default base with your own recipe. In this action, the two recipes are combined, with any conflict (an overlap in the second) being given preference. For example, if the first deid you load removes a field and the second adds the same field, the final result will have it added. Keep this in mind and take care when combining recipes for this reason. Here is how it would look to load the default base *and* provide you custom file:
+
+```
+recipe = DeidRecipe(deid=deid_file, base=True)
+```
+
+You can also specify a different base entirely, and this would be equivalent to just providing a list of deid files:
+
+```
+recipe = DeidRecipe(deid=[deid_file1, deid_file2])
+recipe = DeidRecipe(deid=deid_file1, base=True, default_base=deid_file2)
+```
+
+When we load bases, we are looking in the [data folder](https://github.com/pydicom/deid/tree/master/deid/data) provided by the module. The base is the deid.<tag> in this folder. So for example, if we wanted to use `deid/data/deid.dicom.chest.xray` we would specify:
+
+```
+# Use dicom.xray.chest as a base
+recipe = DeidRecipe(deid=path, base=True, default_base='dicom.xray.chest')
+
+# Use dicom.xray.chest as the only one
+recipe = DeidRecipe(deid='dicom.xray.chest')
+
+# On top of the default base, deid.dicom
+recipe = DeidRecipe(deid='dicom.xray.chest', base=True)
+```
+
+This data folder is to encourage sharing! It often is a lot of work to develop a criteria specific for your group or interest. If you have a general recipe that others might use, please [contribute it](https://github.com/pydicom/deid/blob/master/CONTRIBUTING.md#pull-request-process).
+
+### Filters
+The process of flagging images comes down to writing a set of filters to
+check if each image meets some criteria of interest. For example, I might
+create a filter called "xray" that is triggered when the Modality is CT or XR.
+The filters are found in the `%filter` sections of the deid recipe. 
+
+First, to get a complete dict of all filters (a dictionary with keys corresponding to filter group names and values the filters themselves) we can do the following actions:
+
+```
+recipe.get_filters()
+
+# To get the group names
+recipe.ls_filters()
+# ['whitelist', 'blacklist']
+
+# To get a list of specific filters under a group
+recipe.get_filters('blacklist')
+```
+
+These functions are primarily use internally to get filter lists. Do you have a good use case for wanting a function like add_filter or remove_filter? Please [file an issue](https://www.github.com/pydicom/deid/issues) and we can develop something for it.
+
+### Header Actions
+A header action is a step (e.g., replace, remove, blank) to be applied to
+a dicom image header. The headers are also part of the deid recipe. You
+don't need to necessarily use header actions and filters at the same time, but since
+it's nice to keep things tidy for a single dataset using a shared file, we support having them both
+represented in the same file. You could just as easily keep them in separate files to load separately - a DeidRecipe is not
+required to have header actions and/or filters.
+
+First, let's load the default deid recipe file (deid.dicom in the data folder) that we know has a `%header` section.
+
+```
+recipe = DeidRecipe()
+```
+
+Here is how to get and interact with actions defined by the recipe.
+
+```
+# We can get a complete list of actions
+recipe.get_actions()
+
+# We can filter to an action type
+recipe.get_actions(action='ADD')
+
+#[{'action': 'ADD',
+#  'field': 'IssuerOfPatientID',
+#  'value': 'STARR. In an effort to remove PHI all dates are offset from their original values.'},
+# {'action': 'ADD',
+#  'field': 'PatientBirthDate',
+#  'value': 'var:entity_timestamp'},
+# {'action': 'ADD', 'field': 'StudyDate', 'value': 'var:item_timestamp'},
+# {'action': 'ADD', 'field': 'PatientID', 'value': 'var:entity_id'},
+# {'action': 'ADD', 'field': 'AccessionNumber', 'value': 'var:item_id'},
+# {'action': 'ADD', 'field': 'PatientIdentityRemoved', 'value': 'Yes'}]
+
+# or we can filter to a field
+recipe.get_actions(field='PatientID')
+
+#[{'action': 'REMOVE', 'field': 'PatientID'},
+# {'action': 'ADD', 'field': 'PatientID', 'value': 'var:entity_id'}]
+
+# and logically, both
+recipe.get_actions(field='PatientID', action="REMOVE")
+#  [{'action': 'REMOVE', 'field': 'PatientID'}]
+```
+
+Again, if you have need for more advanced functions, please [file an issue](https://www.github.com/pydicom/deid/issues).
+
+## Replace Identifiers
+
+The `%header` section of a deid recipe defines a set of actions and associated
+fields to perform them on. As we saw in the examples above, we could easily
+view and filter the actions based on the header field or action type.
+For this next section, we will pretend that we've just extracted ids from
+our data files (in a dictionary called ids) and we will prepare a second
+dictionary of updated fields.
+
+
+In this first step, let's import needed functions and load a set of cookie dicoms!
+```
+from deid.dicom import get_files, replace_identifiers
+from deid.utils import get_installdir
+from deid.data import get_dataset
+import os
+
+# This will get a set of example cookie dicoms
+base = get_dataset('dicom-cookies')
+dicom_files = get_files(base)
+```
+
+Here is the function to get identifiers
+
+```
+from deid.dicom import get_identifiers
+ids = get_identifiers(dicom_files)
+```
+
+Remember, the data above probably has PHI in it (e.g., a real `PatientID` and at this point
+you might save them in your special (IRB approvied) places, and then do some action to
+provide replacement anonymous ids to put back in the data. We provide a cookie tumor example
+of doing this below.
+
+```
+# Load the dummy / example deid
+path = os.path.abspath("%s/../examples/deid/" %get_installdir())
+recipe = DeidRecipe(deid=path)
+```
+
+We can quickly double check the actions that are defined
+
+```
+recipe.get_actions()
+
+[{'action': 'ADD', 'field': 'PatientIdentityRemoved', 'value': 'Yes'},
+ {'action': 'REPLACE', 'field': 'PatientID', 'value': 'var:id'},
+ {'action': 'REPLACE', 'field': 'SOPInstanceUID', 'value': 'var:source_id'}]
+```
+
+The above says that we are going to:
+
+ -  `ADD` a field `PatientIdentityRemoved` with value `Yes`
+ -  `REPLACE` `PatientID` with whatever value is under "id" in our updated lookup
+ -  `REPLACE` `SOPInstanceUID` with whatever value is under "source_id"
+
+We have 7 dicom cookie images we loaded above, so we have two options. We can
+either loop through the dictionary of ids and update values (in this case,
+adding values to be used as new variables) or we can make a new datastructure. 
+Let's be lazy and just update the extracted ones
+
+```
+updated_ids = dict(); count=0
+for image, fields in ids.items():    
+    fields['id'] = 'cookiemonster'
+    fields['source_id'] = "cookiemonster-image-%s" %(count)
+    updated_ids[image] = fields
+    count+=1
+```
+
+You can look at each of the updated_ids entries and see the added variables
+
+```
+updated_ids
+
+...
+
+  'id': 'cookiemonster',
+  'source_id': 'cookiemonster-image-2'}}
+```
+
+And then use the deid recipe and updated to create new files
+
+```
+cleaned_files = replace_identifiers(dicom_files=dicom_files,
+                                    deid=recipe,
+                                    ids=updated_ids)
+
+```
+
+To check your work, you can load in a cleaned file to see what was done
+
+```
+from pydicom import read_file
+test_file = read_file(cleaned_files[0])
+
+# test_file
+# (0008, 0018) SOP Instance UID                    UI: cookiemonster-image-1
+# (0010, 0020) Patient ID                          LO: 'cookiemonster'
+# (0012, 0062) Patient Identity Removed            CS: 'Yes'
+# (0028, 0002) Samples per Pixel                   US: 3
+# (0028, 0010) Rows                                US: 1536
+# (0028, 0011) Columns                             US: 2048
+# (7fe0, 0010) Pixel Data                          OB: Array of 738444 bytes
+```
+
+And finally, a few extra customizations for different output folders and settings.
+
+```
+# Different output folder
+cleaned_files = replace_identifiers(dicom_files=dicom_files,
+                                    ids=updated_ids,
+                                    output_folder='/home/vanessa/Desktop')
+
+# Force overwrite (be careful!)
+cleaned_files = replace_identifiers(dicom_files=dicom_files,
+                                    ids=updated_ids,
+                                    output_folder='/home/vanessa/Desktop',
+                                    overwrite=True)
+```

--- a/examples/dicom/deid-dicom-example.py
+++ b/examples/dicom/deid-dicom-example.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
+from deid.dicom import get_files, replace_identifiers
+from deid.utils import get_installdir
+from deid.data import get_dataset
+import os
+
 # This is a complete example of doing de-identifiction. For details, see our docs
 # https://pydicom.github.io/deid
 
 
 # This will get a set of example cookie dicoms
-from deid.dicom import get_files
-from deid.data import get_dataset
-from deid.dicom import replace_identifiers
 base = get_dataset('dicom-cookies')
 dicom_files = get_files(base)
 
@@ -22,31 +24,172 @@ ids = get_identifiers(dicom_files)
 # A cookie tumor example is below
 #**
 
-# Load your custom deid parameters (see deid folder under examples)
-from deid.utils import get_installdir
-from deid.config import load_deid
-import os
+################################################################################
+# The Deid Recipe
+#
+# The process of flagging images comes down to writing a set of filters to
+# check if each image meets some criteria of interest. For example, I might
+# create a filter called "xray" that is triggered when the Modality is CT or XR.
+# We specify these fliters in a simple text file called a "deid recipe." When
+# you work with the functions, you have the choice to instantiate the object
+# in advance, or just provide a path to a recipe file. We will walk through
+# examples  for both below, starting with working with a DeidRecipe object.
+# If you aren't interested in this use case or just want to use a provided
+# deid recipe file, continue to the step to replace_identifiers
+#
+##################################
 
+# Create a DeidRecipe
+from deid.config import DeidRecipe
+recipe = DeidRecipe()
+
+# Since we didn't load a custom deid recipe text file, we get a default
+# WARNING No specification, loading default base deid.dicom
+# You can add custom deid files with .load().
+
+# We can look at the criteria loaded:
+recipe.deid
+
+# You can also provide your own deid recipe file, and in doing so, you
+# won't load a default
 path = os.path.abspath("%s/../examples/deid/" %get_installdir())
+recipe = DeidRecipe(deid=path)
 
-# If you are intereseted to see it, but you don't have to do this,
-# this happens internally
-deid = load_deid(path)
+# You can also choose to load the default base with your own recipe
+recipe = DeidRecipe(deid=path, base=True)
+
+# Or specify a different base entirely. The base is the deid.<tag> in the
+# deid.data folder. So for example, under deid/data/deid.dicom.chest.xray we would
+# do:
+recipe = DeidRecipe(deid=path, base=True, default_base='dicom.xray.chest')
+
+# We can also specify one of the deid recipes provided by the library as our 
+# only to use.
+recipe = DeidRecipe(deid='dicom.xray.chest')
+
+# This is to encourage sharing! If you have a general recipe that others might
+# use, please contribute it to the library.
+
+# You can also load multiple deid files, just put them in a list in the order
+# that you want them loaded.
+
+# To see an entire (raw in a dictionary) recipe just look at
+recipe.deid
+
+# Now let's look at parts of this recipe. There are two categories of things: 
+# - filters: are used for parsing over headers and flagging images 
+# - header: is a set of rules that govern a replacement procedure
+
+################################################################################
+# Format
+################################################################################
+
+recipe.get_format()
+# dicom
 
 
-# Let's add the fields that we specify to add in our deid, a source_id for SOPInstanceUID,
-# and an id for PatientID
-count=0
-updated_ids = dict()
-for image,fields in ids.items():    
+################################################################################
+# Filters
+################################################################################
+
+# To get a complete dict of all filters, key (index) is by filter group
+recipe.get_filters()
+
+# To get the group names
+recipe.ls_filters()
+# ['whitelist', 'blacklist']
+
+# To get a list of specific filters under a group
+recipe.get_filters('blacklist')
+
+
+################################################################################
+# Header Actions
+# A header action is a step (e.g., replace, remove, blank) to be applied to
+# a dicom image header. The headers are also part of the deid recipe, and you
+# don't need to necessarily use header actions and filters at the same time.
+################################################################################
+
+# For the example we were doing above, the recipe didn't have a header section.
+# Let's load one that does.
+recipe = DeidRecipe()
+
+# We can get a complete list of actions
+recipe.get_actions()
+
+# We can filter to an action type
+recipe.get_actions(action='ADD')
+
+#[{'action': 'ADD',
+#  'field': 'IssuerOfPatientID',
+#  'value': 'STARR. In an effort to remove PHI all dates are offset from their original values.'},
+# {'action': 'ADD',
+#  'field': 'PatientBirthDate',
+#  'value': 'var:entity_timestamp'},
+# {'action': 'ADD', 'field': 'StudyDate', 'value': 'var:item_timestamp'},
+# {'action': 'ADD', 'field': 'PatientID', 'value': 'var:entity_id'},
+# {'action': 'ADD', 'field': 'AccessionNumber', 'value': 'var:item_id'},
+# {'action': 'ADD', 'field': 'PatientIdentityRemoved', 'value': 'Yes'}]
+
+# or we can filter to a field
+recipe.get_actions(field='PatientID')
+
+#[{'action': 'REMOVE', 'field': 'PatientID'},
+# {'action': 'ADD', 'field': 'PatientID', 'value': 'var:entity_id'}]
+
+# and logically, both
+recipe.get_actions(field='PatientID', action="REMOVE")
+#  [{'action': 'REMOVE', 'field': 'PatientID'}]
+
+
+################################################################################
+# Replacing Identifiers
+#
+# The %header section of a deid recipe defines a set of actions and associated
+# fields to perform them on. As we saw in the examples above, we could easily
+# view and filter the actions based on the header field or action type.
+#
+# For this next section, we will pretend that we've just extracted ids from
+# our data files (in a dictionary called ids) and we will prepare a second
+# dictionary of updated fields.
+
+##################################
+
+# Load the dummy / example deid
+path = os.path.abspath("%s/../examples/deid/" %get_installdir())
+recipe = DeidRecipe(deid=path)
+
+# What actions are defined?
+recipe.get_actions()
+
+# [{'action': 'ADD', 'field': 'PatientIdentityRemoved', 'value': 'Yes'},
+#  {'action': 'REPLACE', 'field': 'PatientID', 'value': 'var:id'},
+#  {'action': 'REPLACE', 'field': 'SOPInstanceUID', 'value': 'var:source_id'}]
+
+# The above says that we are going to:
+#  ADD a field PatientIdentityRemoved with value Yes
+#  REPLACE PatientID with whatever value is under "id" in our updated lookup
+#  REPLACE SOPInstanceUID with whatever value is under "source_id"
+
+# We have 7 dicom cookie images we loaded above, so we have two options. We can
+# either loop through the dictionary of ids and update values (in this case,
+# adding values to be used as new variables) or we can make a new datastructure
+
+# Let's be lazy and just update the extracted ones
+updated_ids = dict(); count=0
+for image, fields in ids.items():    
     fields['id'] = 'cookiemonster'
     fields['source_id'] = "cookiemonster-image-%s" %(count)
     updated_ids[image] = fields
     count+=1
 
-# Run again, provided the path to deid, and the updated ids
+# You can look at each of the updated_ids entries and see the added variables
+#  'id': 'cookiemonster',
+#  'source_id': 'cookiemonster-image-2'}}
+
+# And then use the deid recipe and updated to create new files
 cleaned_files = replace_identifiers(dicom_files=dicom_files,
-                                    deid=path,
+                                    deid=recipe,
                                     ids=updated_ids)
 
 


### PR DESCRIPTION
This PR is based on discussion with @BrianKolowitz to add a proper DeidRecipe class that can handle loading (and then other operations) with deid recipe files. This first implementation has basic functions to load single, multiple, and control defaults, as well as retrieve / filter different actions and filters. The class is shown here and a walk through of using it provided as a script. I've also added updated docs (tutorial) for the cleaner (previously only existed as a script in the examples folder).