### PR TITLE
tweaking item ids to use full file name / path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
  - migration guidance (how to convert images?)
  - changed behaviour (recipe sections work differently)
 
-## [vxx](https://github.com/pydicom/deid/tree/development) (development)
+Referenced versions in headers are tagged on Github, in parentheses are for pypi.
+
+## [vxx](https://github.com/pydicom/deid/tree/master) (development)
 
 **additions**
+ - ensuring that ids for images are full paths (0.1.11)
  - addition of the DeidRecipe class to better interact with and combine deid recipe files.
  - the get_files function now returns a generator instead of a list.
 

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -95,7 +95,6 @@ def get_shared_identifiers(dicom_files,
     # We will skip PixelData
     skip = config['skip']
     for dicom_file in dicom_files:
-        item_id = os.path.basename(dicom_file)
         dicom = read_file(dicom_file,force=True)
         fields = get_fields(dicom,
                             skip=skip,
@@ -167,13 +166,12 @@ def get_identifiers(dicom_files,
         skip = skip + skip_fields
  
     for dicom_file in dicom_files:
-        item_id = os.path.basename(dicom_file)
         dicom = read_file(dicom_file,force=True)
 
-        if item_id not in ids:
-            ids[item_id] = dict()
+        if dicom_file not in ids:
+            ids[dicom_file] = dict()
 
-        ids[item_id] = get_fields(dicom,
+        ids[dicom_file] = get_fields(dicom,
                                   skip=skip,
                                   expand_sequences=expand_sequences)
     return ids

--- a/deid/version.py
+++ b/deid/version.py
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
-__version__ = "0.1.1"
+__version__ = "0.1.11"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
@johannesu see this PR - this would change the `item_id` (the index for the identifiers) to not be the basename, but maintain the overall path. Would you like to test to see if it addresses #44 ?