### PR TITLE
Support passing Dataset objects instead of requiring FileDataset objects

### DIFF
--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -86,7 +86,6 @@ def _perform_action(dicom,field,action,value=None,item=None):
     Both result in a call to this function. If an action fails or is not
     done, None is returned, and the calling function should handle this.
     '''
-    dicom_file = os.path.basename(dicom.filename)    
     if action not in valid_actions:
         bot.warning('%s in not a valid choice [%s]. Defaulting to blanked.' %(action,
                                                                               ".".join(valid_actions)))

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -83,7 +83,6 @@ def get_fields(dicom, skip=None, expand_sequences=True):
         skip = [skip]
     fields = dict()
     contenders = dicom.dir()
-    dicom_file = os.path.basename(dicom.filename)
     for contender in contenders:
         if contender in skip:
             continue

--- a/deid/dicom/tags.py
+++ b/deid/dicom/tags.py
@@ -112,9 +112,8 @@ def add_tag(dicom,field,value, quiet=False):
     :param field: the name of the field to add
     :param value: the value to set, if name is a valid tag
     '''
-    dicom_file = os.path.basename(dicom.filename)
     if quiet is False:
-        bot.debug("Attempting ADDITION of %s to %s." %(field,dicom_file))
+        bot.debug("Attempting ADDITION of %s to %s." %(field))
     dicom = change_tag(dicom,field,value)
  
     # dicom.data_element("PatientIdentityRemoved")
@@ -128,7 +127,6 @@ def change_tag(dicom,field,value):
     update_tag or add_tag. The only difference is the print output,
     and determining to call the function based on different conditions
     '''
-    dicom_file = os.path.basename(dicom.filename)
     tag = get_tag(field)
 
     if field in tag:

--- a/deid/dicom/utils.py
+++ b/deid/dicom/utils.py
@@ -153,8 +153,7 @@ def _perform_action(dicom,field,action,value=None,item=None):
     Both result in a call to this function. If an action fails or is not
     done, None is returned, and the calling function should handle this.
     '''
-    dicom_file = os.path.basename(dicom.filename)
-    
+
     done = False
     result = None
 
@@ -204,9 +203,7 @@ def _perform_action(dicom,field,action,value=None,item=None):
             done = True
 
         if not done:            
-            bot.warning("%s %s not done for %s" %(action,
-                                                  field,
-                                                  dicom_file))
+            bot.warning("%s %s not done" %(action, field))
 
     elif action == "ADD":
         value = parse_value(item,value)


### PR DESCRIPTION
We typically operate on pydicom.Dataset objects, and everything is not necessarily files on disk. This PR removes the requirement to provide a filename for all Dataset objects, thay may be streams that exist in memory and are not directly referenced as a file on disk.

Since the filename variable is only used for logging purposes, this can be removed without losing any features.