### PR TITLE
Fixed region anonymization (vertical vs horizontal coordinates)

### DIFF
--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -119,7 +119,7 @@ class DicomCleaner():
 
             for coordinate in coordinates:
                 minr, minc, maxr, maxc = coordinate
-                self.cleaned[minr:maxr, minc:maxc] = 0  # should fill with black
+                self.cleaned[minc:maxc, minr:maxr] = 0  # should fill with black
                                            
 
     def get_figure(self, show=False, image_type="cleaned", title=None):


### PR DESCRIPTION
Before the bug is fixed, notice that the area on the left is blacked out, however, PHI information is across the top of the screen (I did blur it, as this is a real image)
![badly_cleaned](https://user-images.githubusercontent.com/38636124/45109673-36b09200-b10e-11e8-9fa6-46e26a1ffe05.png)

After this proposed fix, the black box correctly blanks out the top region of the image leaving the rest of the image intact.
![cleaned_correctly](https://user-images.githubusercontent.com/38636124/45109709-4f20ac80-b10e-11e8-9551-f0a89678c7cf.png)
