### PR TITLE
fixing save for compressed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - fixing issue #65, save for compressed data (0.1.17)
  - matplotlib must be less than or equal to 2.1.2 for install (0.1.16)
  - fixing bug with clean coordinate flipping rectangle
  - Fixing bug with saving self.cleaned (0.1.15)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/config/__init__.py
+++ b/deid/config/__init__.py
@@ -2,7 +2,7 @@
 
 DeidRecipe
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/config/standards.py
+++ b/deid/config/standards.py
@@ -1,7 +1,7 @@
 '''
 standards.py: standards for configuration
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -1,7 +1,7 @@
 '''
 utils.py: util functions for working with deid configuration files
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -1,7 +1,7 @@
 '''
 actions.py: actions to take on dicom header fields
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -1,7 +1,7 @@
 '''
 header.py: functions to extract identifiers from dicom headers
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/filter.py
+++ b/deid/dicom/filter.py
@@ -1,7 +1,7 @@
 '''
 base.py: base filters for any kind of test
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -1,7 +1,7 @@
 '''
 header.py: functions to extract identifiers from dicom headers
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -1,7 +1,7 @@
 '''
 clean.py: functions for pixel scrubbing
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -178,6 +178,9 @@ class DicomCleaner():
         if hasattr(self, image_type):
             dicom_name = self._get_clean_name(output_folder)
             dicom = read_file(self.dicom_file,force=True)
+            # If going from compressed, change TransferSyntax
+            if dicom.file_meta.TransferSyntaxUID.is_compressed is True:
+                dicom.decompress()
             dicom.PixelData = self.cleaned.tostring()
             dicom.save_as(dicom_name)
             return dicom_name

--- a/deid/dicom/tags.py
+++ b/deid/dicom/tags.py
@@ -1,7 +1,7 @@
 '''
 tags.py: working with header field tags
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/utils.py
+++ b/deid/dicom/utils.py
@@ -1,7 +1,7 @@
 '''
 utils.py: helper functions for working with dicom module
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/dicom/validate.py
+++ b/deid/dicom/validate.py
@@ -1,7 +1,7 @@
 '''
 utils.py: helper functions for working with dicom module
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/identifiers/actions.py
+++ b/deid/identifiers/actions.py
@@ -2,7 +2,7 @@
 actions.py: perform general actions with an input data structure, and
             return a new output.
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/identifiers/tasks.py
+++ b/deid/identifiers/tasks.py
@@ -1,7 +1,7 @@
 '''
 clean.py: tasks for data structure based on a deid specification
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/identifiers/utils.py
+++ b/deid/identifiers/utils.py
@@ -1,7 +1,7 @@
 '''
 utils.py: util functions for identifier objects
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/logger/message.py
+++ b/deid/logger/message.py
@@ -2,7 +2,7 @@
 
 logger/message.py: Python logger base
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/logger/spinner.py
+++ b/deid/logger/spinner.py
@@ -2,7 +2,7 @@
 
 logger/spinner.py: Simple spinner for logger
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/main/__init__.py
+++ b/deid/main/__init__.py
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@ SOFTWARE.
 '''
 
 from glob import glob
-import deid
+from deid.version import __version__
 import tempfile
 import argparse
 import sys
@@ -39,10 +39,6 @@ def get_parser():
     description="Deid (de-identification, anonymization) command line tool.")
 
     # Global Variables
-    parser.add_argument("--version","-v", dest='version', 
-                        help="show deid software version", 
-                        default=False, action='store_true')
-
     parser.add_argument('--quiet',"-q", dest="quiet", 
                         help="Quiet the verbose output", 
                         default=False, action='store_true')
@@ -69,6 +65,9 @@ def get_parser():
                                        dest="command")
 
 
+    version = subparsers.add_parser("version",
+                                    help="print version and exit")
+ 
     # Checks (checks / tests for various services)
     inspect = subparsers.add_parser("inspect",
                                     help="various checks for PHI and quality")
@@ -139,8 +138,8 @@ def main():
     except:
         sys.exit(0)
 
-    if args.version is True:
-        print(deid.__version__)
+    if args.command == "version" or args.version is True:
+        print(__version__)
         sys.exit(0)
 
     # if environment logging variable not set, make silent

--- a/deid/main/identifiers.py
+++ b/deid/main/identifiers.py
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/main/inspect.py
+++ b/deid/main/inspect.py
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/tests/test_config.py
+++ b/deid/tests/test_config.py
@@ -5,7 +5,7 @@ Test config (deid) parsing functions
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/tests/test_data.py
+++ b/deid/tests/test_data.py
@@ -5,7 +5,7 @@ Test data functions
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/tests/test_dicom_tags.py
+++ b/deid/tests/test_dicom_tags.py
@@ -5,7 +5,7 @@ Test dicom tags
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/tests/test_dicom_utils.py
+++ b/deid/tests/test_dicom_utils.py
@@ -5,7 +5,7 @@ Test dicom utils
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/tests/test_utils.py
+++ b/deid/tests/test_utils.py
@@ -5,7 +5,7 @@ Test utils
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017 Vanessa Sochat
+Copyright (c) 2016-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/utils.py
+++ b/deid/utils.py
@@ -3,7 +3,7 @@
 '''
 utils.py: part of deid package
 
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deid/version.py
+++ b/deid/version.py
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
This will close #65 by doing a check for compressed data, and if compressed, we use `dicom.decompress()` to adjust the Transfer Syntax. Discussion and help from @scaramallion is shown here https://github.com/pydicom/pydicom/issues/738#issuecomment-421581350.

I have also updated headers (date for 2018) and fixed an issue with showing the version to close #66. @

@fimafurman we are ready for testing! Note that this compressed data doesn't load in my goto viewer (normally brain images I use mricron) but dropping into Papaya worked like a charm!

 - Papaya[http://rii.uthscsa.edu/mango/papaya/]

![image](https://user-images.githubusercontent.com/814322/45587637-59913200-b8d6-11e8-90c6-6c771ccc5314.png)
