### PR TITLE
Removing unnecessary output folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - need to clean up temporary directory (mkdtemp), issue #68 (0.1.18)
  - fixing issue #65, save for compressed data (0.1.17)
  - matplotlib must be less than or equal to 2.1.2 for install (0.1.16)
  - fixing bug with clean coordinate flipping rectangle

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -24,11 +24,10 @@ SOFTWARE.
 
 from deid.config import DeidRecipe
 from deid.logger import bot
+from deid.utils import get_temporary_name
 from pydicom import read_file
 import matplotlib
 matplotlib.use('pdf')
-import tempfile
-import shutil
 import os
 import re
 
@@ -53,9 +52,7 @@ class DicomCleaner():
                        force=True):
 
         if output_folder is None:
-            # Generate only for name, will be created when save called
-            output_folder = tempfile.mkdtemp()
-            shutil.rmtree(output_folder)
+            output_folder = get_temporary_name(prefix="clean")
 
         if font is None:
             font = self.default_font()

--- a/deid/tests/test_utils.py
+++ b/deid/tests/test_utils.py
@@ -27,7 +27,8 @@ SOFTWARE.
 
 '''
 
-from deid.utils import get_installdir
+from deid.utils import get_installdir,
+ 
 from numpy.testing import (
     assert_array_equal, 
     assert_almost_equal, 
@@ -52,6 +53,19 @@ class TestUtils(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
         print("\n######################END########################")
 
+    def test_get_temporary_name(self):
+        '''test_get_temporary_name will test the generation of a temporary 
+           file name.
+        '''
+        from deid.utils import get_temporary_name
+        print("Testing utils.get_temporary_name...")
+        tmpname = get_temporary_name()
+        self.assertTrue(not os.path.exists(tmpname))
+        self.assertTrue('deid' in tmpname)
+        tmpname = get_temporary_name(prefix='clean')
+        self.assertTrue('deid-clean' in tmpname)
+        tmpname = get_temporary_name(ext='.dcm')
+        self.assertTrue(tmpname.endswith('.dcm'))
 
     def test_write_read_files(self):
         '''test_write_read_files will test the functions 

--- a/deid/tests/test_utils.py
+++ b/deid/tests/test_utils.py
@@ -27,7 +27,7 @@ SOFTWARE.
 
 '''
 
-from deid.utils import get_installdir,
+from deid.utils import get_installdir
  
 from numpy.testing import (
     assert_array_equal, 

--- a/deid/utils.py
+++ b/deid/utils.py
@@ -29,7 +29,7 @@ import json
 import os
 import re
 import requests
-import json
+import tempfile
 from deid.logger import bot
 from collections import OrderedDict
 import sys
@@ -40,9 +40,9 @@ if sys.version_info[0] < 3:
     from exceptions import OSError
 
 
-######################################################################################
+################################################################################
 # Local commands and requests
-######################################################################################
+################################################################################
 
 def get_installdir():
     '''get_installdir returns the installation directory of the application
@@ -50,10 +50,30 @@ def get_installdir():
     return os.path.abspath(os.path.dirname(__file__))
 
 
+def get_temporary_name(prefix=None, ext=None):
+    '''get a temporary name, can be used for a directory or file. This does so
+       without creating the file, and adds an optional prefix
+  
+       Parameters
+       ==========
+       prefix: if defined, add the prefix after deid
+       ext: if defined, return the file extension appended. Do not specify "."
+    '''
+    deid_prefix = 'deid-'
+    if prefix:
+        deid_prefix = 'deid-%s-' % prefix
 
-############################################################################
-## FILE OPERATIONS #########################################################
-############################################################################
+    tmpname = os.path.join(tempfile.gettempdir(), 
+                           '%s%s' % (deid_prefix,
+                                     next(tempfile._get_candidate_names())))
+    if ext:
+        tmpname = '%s.%s' % (tmpname, ext)
+    return tmpname
+
+
+################################################################################
+## FILE OPERATIONS #############################################################
+################################################################################
 
 def write_file(filename,content,mode="w"):
     '''write_file will open a file, "filename" and write content, "content"

--- a/deid/version.py
+++ b/deid/version.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2017 Vanessa Sochat
+Copyright (c) 2017-2018 Vanessa Sochat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
This PR will address and close #68 by only generating a name for an output folder, and recreating the folder only given that a save is called. 