### PR TITLE
testing fix to dockerfile with order of installing pydicom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.0.23)
  - updating deid.dicom with contribution from @fimafurman [#63](https://github.com/pydicom/deid/issues/63) (0.1.22)
  - adding "func" option for recipe to pass function (0.1.21)
  - fixing client bug, redoing docs to be better organized (0.1.20)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM continuumio/miniconda3
 
 RUN apt-get update && apt-get install -y wget git pkg-config libfreetype6-dev
-RUN pip install pydicom
 RUN /opt/conda/bin/conda install matplotlib==2.1.2
+RUN pip install pydicom
 RUN mkdir /code
 ADD . /code
 WORKDIR /code

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
# Description

The issue https://github.com/pydicom/deid/issues/81 reports that the order of installing pydicom *before* a specific version of matplotlib leads to a change in python so pydicom is not found. This PR will adjust the ordering, installing pydicom after, to hopefully fix the issue.

Related issues: # 81

Please test the following container:

```bash
docker run pydicom/deid:0.0.23
```
Note that the tag version is off, which is okay because it's just a testing container :) 