### PR TITLE
jitter_timestamp with variable name change

### DIFF
--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -183,7 +183,7 @@ def jitter_timestamp(dicom, field, value):
             new_value = None
             bot.warning("JITTER not supported for %s with VR=%s" % (field, 
                                                                     dcmvr))
-        if (new_value is not None and new_value is not original):
+        if (new_value is not None and new_value != original):
             # Only update if there's something to update AND there's been change
             dicom = update_tag(dicom,
                                field=field,

--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -166,7 +166,7 @@ def jitter_timestamp(dicom, field, value):
         '''
         if (dcmvr == 'DA'):
             '''
-             NEMA-compliant format for DICOM date is YYYYMMDD
+            NEMA-compliant format for DICOM date is YYYYMMDD
             '''
             new_value = get_timestamp(original, jitter_days=value, 
                                       format='%Y%m%d')
@@ -180,10 +180,12 @@ def jitter_timestamp(dicom, field, value):
                                       format='%Y%m%d%H%M%S.%f%z')
         else:
             # Do nothing and issue a warning.
-            new_value = original
+            new_value = None
             bot.warning("JITTER not supported for %s with VR=%s" % (field, 
                                                                     dcmvr))
-        dicom = update_tag(dicom,
-                           field=field,
-                           value=new_value)
+        if (new_value is not None and new_value is not original):
+            # Only update if there's something to update AND there's been change
+            dicom = update_tag(dicom,
+                               field=field,
+                               value=new_value)
     return dicom

--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -41,6 +41,7 @@ import tempfile
 import os
 import re
 import sys
+import datetime
 
 
 # Actions
@@ -118,7 +119,7 @@ def _perform_action(dicom, field, action, value=None, item=None):
             if value is not None:
 
                 # Jitter the field by the supplied value
-                dicom = jitter_timestamp(item=dicom,
+                dicom = jitter_timestamp(dicom=dicom,
                                          field=field,
                                          value=value)
             else:
@@ -156,6 +157,12 @@ def jitter_timestamp(dicom, field, value):
         value = int(value)
 
     original = dicom.get(field,None)
+    original_date = datetime.datetime.strptime(original, "%Y%m%d")
+    date_added = original_date + datetime.timedelta(days=value)
+       
     if original is not None:
-        dicom[field] = original + value
+        value = "{:%Y%m%d}".format(date_added)
+        dicom = update_tag(dicom,
+                           field=field,
+                           value=value)
     return dicom


### PR DESCRIPTION
JITTER command in recipe generates an error that points to this file.
jitter_timestamp was called in line 121 with "item=dicom" but the
function itself now asks for parameter name "dicom" so changed line 121
to dicom=dicom

Also the code for jitter adding datetime together with simple + in line
160 feels unusual for date operation.  Added new code to utilize
datetime package to do the jitter and updates the dicom field.

In dicom/utils/action.py there is a get_timestamp func which is imported
by actions.py and seems to deal with jitter but looks to be heavier than
necessary since JITTER operates in +/- days only based on Documentation.

Neither current nor old jitter_timestamp uses the get_timestamp
function.

# Description

Related issues: #86 

Please include a summary of the change(s) and if relevant, any related issues above.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
