### PR TITLE
first go to add extra field expanders to close #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - added all, allexcept, contains to field filters (0.1.24)
+ - added all, allexcept, contains to field filters [#87](https://github.com/pydicom/deid/pull/87) (0.1.26)
+ - fixing bug in jitter timestamp function [#85](https://github.com/pydicom/deid/pull/85) (0.1.25)
  - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)
  - updating deid.dicom with contribution from @fimafurman [#63](https://github.com/pydicom/deid/issues/63) (0.1.22)
  - adding "func" option for recipe to pass function (0.1.21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - added all, allexcept, contains to field filters (0.1.24)
  - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)
  - updating deid.dicom with contribution from @fimafurman [#63](https://github.com/pydicom/deid/issues/63) (0.1.22)
  - adding "func" option for recipe to pass function (0.1.21)

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -65,7 +65,7 @@ def expand_field_expression(field, dicom, contenders=None):
     
     '''
     # Expanders that don't have a : must be checked for
-    expanders = ['allfields']
+    expanders = ['all']
 
     # if no contenders provided, use all in dicom headers
     if contenders is None:
@@ -74,7 +74,7 @@ def expand_field_expression(field, dicom, contenders=None):
     # Case 1: field is an expander without an argument (e.g., no :)
     if field.lower() in expanders:
 
-        if field.lower() == "allfields":
+        if field.lower() == "all":
             fields = contenders
         return fields
 
@@ -93,7 +93,7 @@ def expand_field_expression(field, dicom, contenders=None):
         fields = [x for x in contenders if x.lower().endswith(expression)]
     elif expander.lower() == "startswith":
         fields = [x for x in contenders if x.lower().startswith(expression)]
-    elif expander.lower() == "exceptfields":
+    elif expander.lower() == "except":
         fields = [x for x in contenders if not re.search(expression, x.lower())]
     elif expander.lower() == "contains":
         fields = [x for x in contenders if re.search(expression, x.lower())]

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -28,7 +28,7 @@ from pydicom.dataset import RawDataElement
 from deid.logger import bot
 from pydicom import read_file
 import os
-
+import re
 
 def extract_sequence(sequence,prefix=None):
     '''return a pydicom.sequence.Sequence recursively
@@ -53,21 +53,51 @@ def extract_sequence(sequence,prefix=None):
 
 
 
-def expand_field_expression(field,dicom,contenders=None):
+def expand_field_expression(field, dicom, contenders=None):
     '''Get a list of fields based on an expression. If 
-       no expression found, return single field.
+       no expression found, return single field. Options for fields include:
+
+        endswith: filter to fields that end with the expression
+        startswith: filter to fields that start with the expression
+        contains: filter to fields that contain the expression
+        allfields: include all fields
+        exceptfields: filter to all fields except those listed ( | separated)
+    
     '''
+    # Expanders that don't have a : must be checked for
+    expanders = ['allfields']
+
+    # if no contenders provided, use all in dicom headers
+    if contenders is None:
+        contenders = dicom.dir()
+
+    # Case 1: field is an expander without an argument (e.g., no :)
+    if field.lower() in expanders:
+
+        if field.lower() == "allfields":
+            fields = contenders
+        return fields
+
+    # Case 2: The field is a specific field OR an axpander with argument (A:B)
     fields = field.split(':')
     if len(fields) == 1:
         return fields
-    expander,expression = fields
+
+    # if we get down here, we have an expander and expression
+    expander, expression = fields
+    expression = expression.lower()
     fields = []
-    if contenders is None:
-        contenders = dicom.dir()
+
+    # Expanders here require an expression, and have <expander>:<expression>
     if expander.lower() == "endswith":
-        fields = [x for x in contenders if x.endswith(expression)]
+        fields = [x for x in contenders if x.lower().endswith(expression)]
     elif expander.lower() == "startswith":
-        fields = [x for x in contenders if x.startswith(expression)]
+        fields = [x for x in contenders if x.lower().startswith(expression)]
+    elif expander.lower() == "exceptfields":
+        fields = [x for x in contenders if not re.search(expression, x.lower())]
+    elif expander.lower() == "contains":
+        fields = [x for x in contenders if re.search(expression, x.lower())]
+
     return fields
 
 

--- a/deid/tests/test_dicom_tags.py
+++ b/deid/tests/test_dicom_tags.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-
 '''
-Test dicom tags
-
-The MIT License (MIT)
 
 Copyright (c) 2016-2018 Vanessa Sochat
 

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -204,18 +204,72 @@ JITTER endswith:Date var:jitter
 
 and this is the idea of an `expander`. And expander is an optional filter 
 applied to a header field (the middle value) to select some subset of header 
-values. Currently, we support `startswith` and `endswith`. 
-The following examples show what fields are selected based on each filter:
+values. Currently, we support `startswith`, `endswith`, `contains`, `allexcept`,
+and `allfields`.
+ 
+The following examples show what fields are selected based on each filter. For
+all examples, the test is done making the values lowercase.
+
+**endswith**
+
+The endswith filter will look for header field names that end with a particular expression.
+Lower and upper casing does not matter, so writing `endswith:Date` is akin to writing
+`endswith:Date`.
 
 ```
 JITTER endswith:Date var:jitter
 ['AcquisitionDate', 'ContentDate', 'InstanceCreationDate', 'PatientBirthDate', 'PerformedProcedureStepStartDate', 'SeriesDate', 'StudyDate']
+```
 
+**startswith**
 
+The startswith filter will look for header field names that start with a particular expression.
+Casing also doesn't matter.
+
+```
 REMOVE startswith:Patient                  
 ['PatientAddress', 'PatientAge', 'PatientBirthDate', 'PatientID', 'PatientName', 'PatientPosition', 'PatientSex']
 ```
 
+**contains**
+
+The contains filter searches for a string of interest in the field. For example, if
+we ask for fields that contain "Name" will look for header field names that contain the string 
+"Name" in any casing.
+
+
+```
+BLANK contains:Name
+['InstitutionName', 'NameOfPhysiciansReadingStudy', 'OperatorsName', 'PatientName', 'ReferringPhysicianName']
+```
+
+Notice how we get Name in uppercase (when our search string was lowercase) and
+it can appear anywhere in the field.
+
+**allfields**
+
+All fields will allow you to apply a filter to all fields. In the example below,
+we have a function "remove_identifiers" defined in the python environment, and
+will run it over all fields, returning a value to update the field in question.
+
+```
+ADD allfields func:remove_identifiers
+```
+
+**exceptfields**
+
+Akin to all fields, except provide a list of fields that you want to disclude from
+a global selector. Here are some examples to include all fields except StudyDate 
+or StudyTime.
+
+```
+BLANK exceptfields:StudyDate|StudyTime
+BLANK exceptfields:StudyTime
+```
+
+If you are familiar with regular expressions, you'll notice the "|" which 
+means "or" in the regular expression. You are free to write whatever regular
+expression fits your needs to disclude particular fields here.
 
 ## Example
 

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -246,25 +246,25 @@ BLANK contains:Name
 Notice how we get Name in uppercase (when our search string was lowercase) and
 it can appear anywhere in the field.
 
-**allfields**
+**all**
 
 All fields will allow you to apply a filter to all fields. In the example below,
 we have a function "remove_identifiers" defined in the python environment, and
 will run it over all fields, returning a value to update the field in question.
 
 ```
-ADD allfields func:remove_identifiers
+ADD ALL func:remove_identifiers
 ```
 
-**exceptfields**
+**except**
 
 Akin to all fields, except provide a list of fields that you want to disclude from
 a global selector. Here are some examples to include all fields except StudyDate 
 or StudyTime.
 
 ```
-BLANK exceptfields:StudyDate|StudyTime
-BLANK exceptfields:StudyTime
+BLANK except:StudyDate|StudyTime
+BLANK except:StudyTime
 ```
 
 If you are familiar with regular expressions, you'll notice the "|" which 


### PR DESCRIPTION
# Description

This will resolve https://github.com/pydicom/deid/issues/87, adding extra expanders to the selection of fields, including:

 - allfields: to select all fields
 - exceptfields: to select a pipe (|) separated list of fields to not include
 - contains: to select fields based on containing a string (or multiple with pipe)

I have also updated the docs to show examples of the above.