### PR TITLE
adding regular expression parsing to startswith/endswith 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89)
  - added all, allexcept, contains to field filters [#87](https://github.com/pydicom/deid/pull/87) (0.1.26)
  - fixing bug in jitter timestamp function [#85](https://github.com/pydicom/deid/pull/85) (0.1.25)
  - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89)
+ - header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89) (0.1.27)
  - added all, allexcept, contains to field filters [#87](https://github.com/pydicom/deid/pull/87) (0.1.26)
  - fixing bug in jitter timestamp function [#85](https://github.com/pydicom/deid/pull/85) (0.1.25)
  - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -90,9 +90,9 @@ def expand_field_expression(field, dicom, contenders=None):
 
     # Expanders here require an expression, and have <expander>:<expression>
     if expander.lower() == "endswith":
-        fields = [x for x in contenders if x.lower().endswith(expression)]
+        fields = [x for x in contenders if re.search('(%s)$' %expression, x.lower())]
     elif expander.lower() == "startswith":
-        fields = [x for x in contenders if x.lower().startswith(expression)]
+        fields = [x for x in contenders if re.search('^(%s)' %expression, x.lower())]
     elif expander.lower() == "except":
         fields = [x for x in contenders if not re.search(expression, x.lower())]
     elif expander.lower() == "contains":

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.1.26"
+__version__ = "0.1.27"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
Currently, startswith and endswith (header expansion) doesn't support a pipe for OR, like containers. So we can do this:

```
REPLACE contains:Patient Mickey|Minnie
```
but not this

```
REPLACE startswith:Mickey|Minny Mouse
```

This will fix this, making it possible to select a subset of header fields based on startswith or endswith for multiple criteria, and close https://github.com/pydicom/deid/issues/89