### PR TITLE
Update/pixel array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - updating cleaner to use pixel array (0.1.30)
  - validation function should use debug verbository, bumping license year [#92](https://github.com/pydicom/deid/issues/92) (0.1.29)
  - bumping pydicom to 1.2.0 [#91](https://github.com/pydicom/deid/issues/91) (0.1.28)
  - header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89) (0.1.27)

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -105,7 +105,7 @@ class DicomCleaner():
             dicom = read_file(self.dicom_file, force=True)
 
             # We will set original image to image, cleaned to clean
-            self.original = dicom._get_pixel_array()
+            self.original = dicom.pixel_array
             self.cleaned = self.original.copy()
 
             # Compile coordinates from result

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.1.29"
+__version__ = "0.1.30"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'deid'


### PR DESCRIPTION
Another bug - the cleaner needs to use dicom.pixel_array instead of the deprecated dicom._get_pixel_array.