### PR TITLE
remove restriction on matplotlib (results in error)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           conda create --quiet --name testing
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate testing
+          pip install matplotlib
           python setup.py install
 
       - name: Test deid

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     python: "2.7"
 
 install:
-  - pip install pydicom
+  - pip install pydicom matplotlib
   - cd $TRAVIS_BUILD_DIR/
   - python setup.py sdist
   - python setup.py install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - Removing matplotlib dependency (0.1.36)
  - Adding black formatting, tests run in GitHub actions (0.1.35)
  - Adding option to recursively replace sequences (0.1.34)
  - adding pylint to clean up code (0.1.33)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM continuumio/miniconda3
 
-RUN apt-get update && apt-get install -y wget git pkg-config libfreetype6-dev
-RUN /opt/conda/bin/conda install matplotlib==2.1.2
-RUN pip install pydicom==1.1.0
-RUN mkdir /code
-ADD . /code
+RUN apt-get update && apt-get install -y wget git pkg-config libfreetype6-dev g++
+RUN conda install matplotlib
 WORKDIR /code
+ADD . /code
 RUN python /code/setup.py install
 
 RUN chmod 0755 /opt/conda/bin/deid

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include README.md LICENSE
 recursive-include deid *
-prune __pycache__
-prune *.pyc
+global-exclude __pycache__
 prune *.pyc
 prune deid/tests
 prune *OLD

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.1.35"
+__version__ = "0.1.36"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"
@@ -32,7 +32,7 @@ DESCRIPTION = "deidentify dicom and other images with python and pydicom"
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
-    ("matplotlib", {"max_version": "2.1.2"}),
+    ("matplotlib", {"min_version": "2.1.2"}),
     ("pydicom", {"exact_version": "1.2.1"}),
     ("python-dateutil", {"min_version": None}),
 )


### PR DESCRIPTION
This pull request is opened to provide a base for testing / debugging the current issue with updating matplotlib. Specifically, the problem is issue #109 - by setting a max (working) version you have version conflicts when installing with conda. The branch here removes the dependency, and I welcome testers to take it for a spin before we decide to merge proper.

Signed-off-by: vsoch <vsochat@stanford.edu>