### PR TITLE
Adding tag groups for values and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - adding support for tag groups (values, fields) (0.1.4)
  - Adding option to provide function to remove (must return boolean) (0.1.38)
  - removing matplotlib version requirement (0.1.37)
  - Matplotlib dependency >= 2.1.2 (0.1.36)

--- a/deid/config/__init__.py
+++ b/deid/config/__init__.py
@@ -91,28 +91,40 @@ class DeidRecipe:
         """
         section = None
         if self.deid is not None:
-            if name in self.deid:
-                section = self.deid[name]
+            section = self.deid.get(name)
         return section
+
+    # Get Sections
 
     def get_format(self):
         """return the format of the loaded deid, if one exists
         """
         return self._get_section("format")
 
+    def _get_named_section(self, section_name, name=None):
+        """a helper function to return an entire section, or if a name is
+           provided, a named section under it. If the section is not
+           defined, we appropriately return None.
+        """
+        section = self._get_section(section_name)
+        if name is not None and section is not None:
+            section = section.get(name, [])
+        return section
+
     def get_filters(self, name=None):
         """return all filters for a deid recipe, or a set based on a name
         """
-        filters = self._get_section("filter")
-        if name is not None and filters is not None:
-            filters = filters[name]
-        return filters
+        return self._get_named_section("filter", name)
 
-    def ls_filters(self):
-        """list names of filter groups
+    def get_values_lists(self, name=None):
+        """return a values list by name
         """
-        filters = self._get_section("filter")
-        return list(filters.keys())
+        return self._get_named_section("values", name)
+
+    def get_fields_lists(self, name=None):
+        """return a values list by name
+        """
+        return self._get_named_section("fields", name)
 
     def get_actions(self, action=None, field=None):
         """get deid actions to perform on a header, or a subset based on a type
@@ -136,6 +148,38 @@ class DeidRecipe:
                 header = [x for x in header if x["field"].upper() == field]
 
         return header
+
+    # Boolean properties
+
+    def _has_list_content(self, name):
+        return len(self.deid.get(name, [])) > 0
+
+    def has_fields_lists(self):
+        return self._has_list_content("fields")
+
+    def has_values_lists(self):
+        return self._has_list_content("values")
+
+    def has_actions(self):
+        return self._has_list_content("header")
+
+    # Listing
+
+    def listof(self, section):
+        """return a list of keys for a section"""
+        listing = self._get_section(section)
+        return list(listing.keys())
+
+    def ls_filters(self):
+        return self.listof("filter")
+
+    def ls_valuelists(self):
+        return self.listof("values")
+
+    def ls_fieldlists(self):
+        return self.listof("fields")
+
+    # Init
 
     def _init_deid(self, deid=None, base=False, default_base="dicom"):
         """initalize the recipe with one or more deids, optionally including 

--- a/deid/config/__init__.py
+++ b/deid/config/__init__.py
@@ -167,7 +167,7 @@ class DeidRecipe:
 
     def listof(self, section):
         """return a list of keys for a section"""
-        listing = self._get_section(section)
+        listing = self._get_section(section) or {}
         return list(listing.keys())
 
     def ls_filters(self):

--- a/deid/config/standards.py
+++ b/deid/config/standards.py
@@ -31,9 +31,9 @@ sections = ["header", "labels", "filter", "values", "fields"]
 # Supported Header Actions
 actions = ("ADD", "BLANK", "JITTER", "KEEP", "REPLACE", "REMOVE", "LABEL")
 
-# Supported Group actions
-fields_actions = ["FIELD"]
-values_actions = ["FIELD", "SPLIT"]
+# Supported Group actions (SPLIT only supported for values)
+groups = ["values", "fields"]
+group_actions = ("FIELD", "SPLIT")
 
 # Valid actions for a filter action
 filters = (

--- a/deid/config/standards.py
+++ b/deid/config/standards.py
@@ -26,9 +26,14 @@ SOFTWARE.
 formats = ["dicom"]
 
 # Supported Sections
-sections = ["header", "labels", "filter"]
+sections = ["header", "labels", "filter", "values", "fields"]
 
+# Supported Header Actions
 actions = ("ADD", "BLANK", "JITTER", "KEEP", "REPLACE", "REMOVE", "LABEL")
+
+# Supported Group actions
+fields_actions = ["FIELD"]
+values_actions = ["FIELD", "SPLIT"]
 
 # Valid actions for a filter action
 filters = (

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -28,7 +28,7 @@ user can specify a custom name.
 # pylint: skip-file
 
 from deid.logger import bot
-from deid.utils import read_file
+from deid.utils import read_file, get_installdir
 from deid.data import data_base
 from deid.config.standards import (
     formats,
@@ -195,7 +195,7 @@ def load_deid(path=None):
                     section=section, section_name=section_name, line=line, config=config
                 )
         else:
-            bot.debug("%s not recognized to be in valid format, skipping." % line)
+            bot.warning("%s not recognized to be in valid format, skipping." % line)
     return config
 
 
@@ -208,6 +208,9 @@ def find_deid(path=None):
        path: a path on the filesystem. If not provided, will assume PWD.
 
     """
+    # A default deid will be loaded if all else fails
+    default_deid = os.path.join(get_installdir(), "data", "deid.dicom")
+
     if path is None:
         path = os.getcwd()
 
@@ -218,7 +221,11 @@ def find_deid(path=None):
         ]
 
         if len(contenders) == 0:
-            bot.exit("No deid settings files found in %s, exiting." % (path))
+            bot.warning(
+                "No deid settings files found in %s, will use default dicom.deid."
+                % path
+            )
+            contenders.append(default_deid)
 
         elif len(contenders) > 1:
             bot.warning("Multiple deid files found in %s, will use first." % (path))

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -30,8 +30,14 @@ user can specify a custom name.
 from deid.logger import bot
 from deid.utils import read_file
 from deid.data import data_base
-from deid.config.standards import formats, actions, sections, filters
-
+from deid.config.standards import (
+    formats,
+    actions,
+    sections,
+    filters,
+    fields_actions,
+    values_actions,
+)
 from collections import OrderedDict
 import os
 import re
@@ -130,7 +136,7 @@ def load_deid(path=None):
     config = OrderedDict()
     section = None
 
-    while len(spec) > 0:
+    while spec:
 
         # Clean up white trailing/leading space
         line = spec.pop(0).strip()

--- a/deid/dicom/__init__.py
+++ b/deid/dicom/__init__.py
@@ -6,7 +6,5 @@ from .header import (
 )
 
 from .utils import get_files
-
 from .fields import extract_sequence
-
 from .pixels import has_burned_pixels, DicomCleaner

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -91,13 +91,16 @@ def find_by_values(values, dicom):
     """Given a list of values, find fields in the dicom that contain any
        of those values, as determined by a regular expression search.
     """
+    # Values must be strings
+    values = [str(x) for x in values]
+
     fields = []
     contenders = get_fields(dicom)
 
     # Create single regular expression to search by
     regexp = "(%s)" % "|".join(values)
     for field, value in contenders.items():
-        if re.search(regexp, value):
+        if re.search(regexp, value, re.IGNORECASE):
             fields.append(field)
 
     return fields
@@ -127,7 +130,7 @@ def expand_field_expression(field, dicom, contenders=None):
             fields = contenders
         return fields
 
-    # Case 2: The field is a specific field OR an axpander with argument (A:B)
+    # Case 2: The field is a specific field OR an expander with argument (A:B)
     fields = field.split(":")
     if len(fields) == 1:
         return fields

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -87,6 +87,22 @@ def extract_sequence(sequence, prefix=None):
     return items
 
 
+def find_by_values(values, dicom):
+    """Given a list of values, find fields in the dicom that contain any
+       of those values, as determined by a regular expression search.
+    """
+    fields = []
+    contenders = get_fields(dicom)
+
+    # Create single regular expression to search by
+    regexp = "(%s)" % "|".join(values)
+    for field, value in contenders.items():
+        if re.search(regexp, value):
+            fields.append(field)
+
+    return fields
+
+
 def expand_field_expression(field, dicom, contenders=None):
     """Get a list of fields based on an expression. If 
        no expression found, return single field. Options for fields include:
@@ -95,8 +111,7 @@ def expand_field_expression(field, dicom, contenders=None):
         startswith: filter to fields that start with the expression
         contains: filter to fields that contain the expression
         allfields: include all fields
-        exceptfields: filter to all fields except those listed ( | separated)
-    
+        exceptfields: filter to all fields except those listed ( | separated)   
     """
     # Expanders that don't have a : must be checked for
     expanders = ["all"]

--- a/deid/dicom/groups.py
+++ b/deid/dicom/groups.py
@@ -1,0 +1,108 @@
+"""
+
+groups: functions to derive groups of fields or values
+
+Copyright (c) 2020 Vanessa Sochat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+
+from deid.logger import bot
+from .tags import remove_sequences
+from .fields import get_fields, expand_field_expression
+
+import os
+
+
+def extract_values_list(dicom, actions):
+    """Given a list of actions for a named group (a list) extract values from
+       the dicom based on the list of actions provided. This function
+       always returns a list intended to update some lookup to be used
+       to further process the dicom.
+    """
+    values = []
+    fields = get_fields(dicom)
+    for action in actions:
+
+        # Just grab the entire value string for a field, no parsing
+        if action["action"] == "FIELD":
+            subset = expand_field_expression(
+                field=action["field"], dicom=dicom, contenders=fields
+            )
+            [values.append(dicom.get(field)) for field in subset]
+
+        # Split action, can optionally have a "by" and/or minlength parameter
+        elif action["action"] == "SPLIT":
+            subset = expand_field_expression(
+                field=action["field"], dicom=dicom, contenders=fields
+            )
+
+            # Default values for split are length 1 and character empty space
+            bot.debug("Parsing action %s" % action)
+            split_by = " "
+            minlength = 1
+
+            if "value" in action:
+                for param in action["value"].split(";"):
+                    param_name, param_val = param.split("=")
+
+                    # Set a custom parameter legnth
+                    if param_name == "minlength":
+                        minlength = int(param_val)
+                        bot.debug("Minimum length set to %s" % minlength)
+                    elif param_name == "by":
+                        split_by = param_val.strip("'").strip('"')
+                        bot.debug("Splitting value set to %s" % split_by)
+
+            for field in subset:
+                new_values = dicom.get(field, "").split(split_by)
+                for new_value in new_values:
+                    if len(new_value) > minlength:
+                        values.append(new_value)
+
+        else:
+            bot.warning(
+                "Unrecognized action %s for values list extraction." % action["action"]
+            )
+
+    return values
+
+
+def extract_fields_list(dicom, actions):
+    """Given a list of actions for a named group (a list) extract values from
+       the dicom based on the list of actions provided. This function
+       always returns a list intended to update some lookup to be used
+       to further process the dicom.
+    """
+    subset = []
+    fields = get_fields(dicom)
+    for action in actions:
+
+        if action["action"] == "FIELD":
+            subset += expand_field_expression(
+                field=action["field"], dicom=dicom, contenders=fields
+            )
+
+        else:
+            bot.warning(
+                "Unrecognized action %s for fields list extraction." % action["action"]
+            )
+    return subset

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -28,19 +28,17 @@ SOFTWARE.
 from deid.logger import bot
 from deid.utils import read_json
 
-from .tags import remove_sequences
-from .groups import extract_values_list, extract_fields_list
-
-from deid.dicom.tags import get_private
 from deid.config import DeidRecipe
 
 from pydicom import read_file
 
-from .utils import save_dicom
-from .actions import perform_action
-from pydicom.dataset import Dataset
+from deid.dicom.utils import save_dicom
+from deid.dicom.actions import perform_action
+from deid.dicom.tags import remove_sequences, get_private
+from deid.dicom.groups import extract_values_list, extract_fields_list
+from deid.dicom.fields import get_fields
 
-from .fields import get_fields
+from pydicom.dataset import Dataset
 
 import os
 
@@ -137,8 +135,6 @@ def get_identifiers(
         skip_fields: if not None, added fields to skip
 
     """
-    bot.debug("Extracting identifiers for %s dicom" % (len(dicom_files)))
-
     if config is None:
         config = "%s/config.json" % here
 
@@ -149,6 +145,7 @@ def get_identifiers(
     if not isinstance(dicom_files, list):
         dicom_files = [dicom_files]
 
+    bot.debug("Extracting identifiers for %s dicom" % len(dicom_files))
     ids = dict()  # identifiers
 
     # We will skip PixelData
@@ -159,7 +156,13 @@ def get_identifiers(
         skip = skip + skip_fields
 
     for dicom_file in dicom_files:
-        dicom = read_file(dicom_file, force=True)
+
+        # TODO: this should have shared reader class to hold dicom, ids, etc.
+        if isinstance(dicom_file, Dataset):
+            dicom = dicom_file
+            dicom_file = dicom.filename
+        else:
+            dicom = read_file(dicom_file, force=force)
 
         if dicom_file not in ids:
             ids[dicom_file] = dict()
@@ -253,7 +256,12 @@ def replace_identifiers(
     # Parse through dicom files, update headers, and save
     updated_files = []
     for _, dicom_file in enumerate(dicom_files):
-        dicom = read_file(dicom_file, force=force)
+
+        if isinstance(dicom_file, Dataset):
+            dicom = dicom_file
+            dicom_file = dicom.filename
+        else:
+            dicom = read_file(dicom_file, force=force)
         dicom_name = os.path.basename(dicom_file)
         fields = dicom.dir()
 
@@ -266,19 +274,19 @@ def replace_identifiers(
             if dicom_file in ids:
 
                 # Prepare additional lists of values and fields (updates item)
-                if deid.has_values_lists():
-                    for group, actions in deid.get_values_lists().items():
+                if recipe.has_values_lists():
+                    for group, actions in recipe.get_values_lists().items():
                         ids[dicom_file][group] = extract_values_list(
                             dicom=dicom, actions=actions
                         )
 
-                if deid.has_fields_lists():
-                    for group, actions in deid.get_fields_lists().items():
+                if recipe.has_fields_lists():
+                    for group, actions in recipe.get_fields_lists().items():
                         ids[dicom_file][group] = extract_fields_list(
                             dicom=dicom, actions=actions
                         )
 
-                for action in deid.get_actions():
+                for action in recipe.get_actions():
                     dicom = perform_action(
                         dicom=dicom, item=ids[dicom_file], action=action
                     )

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -29,6 +29,7 @@ from deid.logger import bot
 from deid.utils import read_json
 
 from .tags import remove_sequences
+from .groups import extract_values_list, extract_fields_list
 
 from deid.dicom.tags import get_private
 from deid.config import DeidRecipe
@@ -261,7 +262,22 @@ def replace_identifiers(
             dicom = remove_sequences(dicom)
 
         if recipe.deid is not None:
+
             if dicom_file in ids:
+
+                # Prepare additional lists of values and fields (updates item)
+                if deid.has_values_lists():
+                    for group, actions in deid.get_values_lists().items():
+                        ids[dicom_file][group] = extract_values_list(
+                            dicom=dicom, actions=actions
+                        )
+
+                if deid.has_fields_lists():
+                    for group, actions in deid.get_fields_lists().items():
+                        ids[dicom_file][group] = extract_fields_list(
+                            dicom=dicom, actions=actions
+                        )
+
                 for action in deid.get_actions():
                     dicom = perform_action(
                         dicom=dicom, item=ids[dicom_file], action=action

--- a/deid/tests/test_config.py
+++ b/deid/tests/test_config.py
@@ -95,7 +95,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(len(unknown), 0)
 
         print("Testing standards: allowed sections")
-        default_sections = ["header", "labels", "filter"]
+        default_sections = ["header", "labels", "filter", "fields", "values"]
         [self.assertTrue(x in sections) for x in default_sections]
         unknown = [x for x in sections if x not in default_sections]
         self.assertEqual(len(unknown), 0)

--- a/deid/tests/test_config.py
+++ b/deid/tests/test_config.py
@@ -56,10 +56,13 @@ class TestConfig(unittest.TestCase):
         config = load_deid(os.path.dirname(self.deid))
         self.assertTrue("format" in config)
 
-        print("Case 3: Testing error on non-existing load")
+        print("Case 3: Testing error on non-existing load of file")
         with self.assertRaises(SystemExit) as cm:
-            config = load_deid(self.tmpdir)
+            config = load_deid(os.path.join(self.tmpdir, "deid.doesnt-exist"))
         self.assertEqual(cm.exception.code, 1)
+
+        print("Case 4: Testing load of default deid.")
+        config = load_deid(self.tmpdir)
 
     def test_find_deid(self):
 

--- a/deid/tests/test_deid_recipe.py
+++ b/deid/tests/test_deid_recipe.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+"""
+Test DeidRecipe class
+
+Copyright (c) 2020 Vanessa Sochat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import unittest
+import tempfile
+import shutil
+import json
+import os
+
+from deid.config import DeidRecipe
+from deid.utils import get_installdir
+
+
+class TestDeidRecipe(unittest.TestCase):
+    def setUp(self):
+        self.pwd = get_installdir()
+        self.deid = os.path.abspath("%s/../examples/deid/deid.dicom" % self.pwd)
+        self.tmpdir = tempfile.mkdtemp()
+        print("\n######################START######################")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        print("\n######################END########################")
+
+    def test_load_recipe(self):
+
+        print("Case 1: Test loading default DeidRecipe")
+
+        recipe = DeidRecipe()
+
+        self.assertTrue(isinstance(recipe.deid, dict))
+
+        print("Checking basic sections are loaded")
+        print(recipe.deid.keys())
+        for section in ["header", "format", "filter"]:
+            self.assertTrue(section in recipe.deid)
+
+        print("Case 2: Loading from file")
+        recipe = DeidRecipe(self.deid)
+
+    def test_get_functions(self):
+
+        recipe = DeidRecipe(self.deid)
+
+        # Format
+        self.assertEqual(recipe.get_format(), "dicom")
+
+        # Actions for header
+        print("Testing get_actions")
+        actions = recipe.get_actions()
+        self.assertTrue(isinstance(actions, list))
+        for key in ["action", "field", "value"]:
+            self.assertTrue(key in actions[0])
+        self.assertTrue(recipe.has_actions())
+
+        # Filters
+        print("Testing get_filters")
+        filters = recipe.get_filters()
+        self.assertTrue(isinstance(filters, dict))
+
+        # whitelist, blacklist, graylist
+        for key in recipe.ls_filters():
+            self.assertTrue(key in filters)
+
+        recipe = DeidRecipe()
+        filters = recipe.get_filters()
+        self.assertTrue(isinstance(filters["whitelist"], list))
+
+        # Test that each filter has a set of filters, coords, name
+        for key in ["filters", "coordinates", "name"]:
+            self.assertTrue(key in filters["whitelist"][0])
+
+        # Each filter is a list of actions, name is string, coords are list
+        self.assertTrue(isinstance(filters["whitelist"][0]["filters"], list))
+        self.assertTrue(isinstance(filters["whitelist"][0]["name"], str))
+        self.assertTrue(isinstance(filters["whitelist"][0]["coordinates"], list))
+
+        # Check content of the first filter
+        for key in ["action", "field", "operator", "InnerOperators", "value"]:
+            self.assertTrue(key in filters["whitelist"][0]["filters"][0])
+
+        # Fields and Values
+        print("Testing get_fields_lists and get_values_lists")
+        self.assertEqual(recipe.get_fields_lists(), None)
+        self.assertEqual(recipe.get_values_lists(), None)
+        self.assertEqual(recipe.ls_fieldlists(), [])
+        self.assertEqual(recipe.ls_valuelists(), [])
+        self.assertTrue(not recipe.has_fields_lists())
+        self.assertTrue(not recipe.has_values_lists())
+
+        # Load in recipe with values and fields
+        deid = os.path.abspath("%s/../examples/deid/deid.dicom-groups" % self.pwd)
+        recipe = DeidRecipe(deid)
+
+        assert "values" in recipe.deid
+        assert "fields" in recipe.deid
+        self.assertTrue(isinstance(recipe.deid["values"], dict))
+        self.assertTrue(isinstance(recipe.deid["fields"], dict))
+
+        self.assertTrue(recipe.get_fields_lists() is not None)
+        self.assertTrue(recipe.get_values_lists() is not None)
+        self.assertEqual(recipe.ls_fieldlists(), ["instance_fields"])
+        self.assertEqual(recipe.ls_valuelists(), ["cookie_names", "operator_names"])
+        self.assertTrue(recipe.has_fields_lists())
+        self.assertTrue(recipe.has_values_lists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deid/tests/test_dicom_groups.py
+++ b/deid/tests/test_dicom_groups.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+"""
+Testing groups for a deid recipe (values and fields)
+
+Copyright (c) 2020 Vanessa Sochat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import unittest
+import tempfile
+import shutil
+import json
+import os
+
+from deid.utils import get_installdir
+from deid.data import get_dataset
+from deid.config import DeidRecipe
+from deid.dicom.fields import get_fields
+from deid.dicom import get_identifiers, replace_identifiers
+
+
+class TestDicomGroups(unittest.TestCase):
+    def setUp(self):
+        self.pwd = get_installdir()
+        self.deid = os.path.abspath("%s/../examples/deid/deid.dicom-groups" % self.pwd)
+        self.dataset = get_dataset("dicom-cookies")
+        self.tmpdir = tempfile.mkdtemp()
+        print("\n######################START######################")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        print("\n######################END########################")
+
+    def test_extract_groups(self):
+        print("Test deid.dicom.groups extract_values_list")
+        from deid.dicom.groups import extract_values_list, extract_fields_list
+
+        dicom = get_dicom(self.dataset)
+        fields = get_fields(dicom)  # removes empty / null
+
+        # Test split action
+        actions = [
+            {"action": "SPLIT", "field": "PatientID", "value": 'by="^";minlength=4'}
+        ]
+        expected_names = dicom.get("PatientID").split("^")
+        actual = extract_values_list(dicom, actions)
+        self.assertEqual(actual, expected_names)
+
+        # Test field action
+        actions = [{"action": "FIELD", "field": "startswith:Operator"}]
+        expected_operator = [dicom.get(x) for x in fields if x.startswith("Operator")]
+        actual = extract_values_list(dicom, actions)
+        self.assertEqual(actual, expected_operator)
+
+        print("Test deid.dicom.groups extract_fields_list")
+        actions = [{"action": "FIELD", "field": "contains:Instance"}]
+        expected = [x for x in fields if "Instance" in x]
+        actual = extract_fields_list(dicom, actions)
+        self.assertEqual(actual, expected)
+
+        # Get identifiers for file
+        ids = get_identifiers(dicom)
+        self.assertTrue(isinstance(ids, dict))
+
+        # Add keys to be used for replace to ids - these first are for values
+        ids[dicom.filename]["cookie_names"] = expected_names
+        ids[dicom.filename]["operator_names"] = expected_operator
+
+        # This is for fields
+        ids[dicom.filename]["instance_fields"] = expected
+        ids[dicom.filename]["id"] = "new-cookie-id"
+        ids[dicom.filename]["source_id"] = "new-operator-id"
+
+        replaced = replace_identifiers(dicom, ids=ids, save=False, deid=self.deid)
+        cleaned = replaced.pop()
+        self.assertEqual(cleaned.get("PatientID"), "new-cookie-id")
+        self.assertEqual(cleaned.get("OperatorsName"), "new-operator-id")
+
+        # Currently we don't well handle tag types, so we convert to string
+        for field in expected_operator:
+            self.assertTrue(str(field) not in cleaned)
+
+
+def get_dicom(dataset):
+    """helper function to load a dicom
+    """
+    from deid.dicom import get_files
+    from pydicom import read_file
+
+    dicom_files = get_files(dataset)
+    return read_file(next(dicom_files))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deid/tests/test_utils.py
+++ b/deid/tests/test_utils.py
@@ -92,7 +92,8 @@ class TestUtils(unittest.TestCase):
         tmpfile = tempfile.mkstemp()[1]
         os.remove(tmpfile)
         write_json(good_json, tmpfile)
-        content = json.load(open(tmpfile, "r"))
+        with open(tmpfile, "r") as fd:
+            content = json.loads(fd.read())
         self.assertTrue(isinstance(content, dict))
         self.assertTrue("Wakkawakkawakka" in content)
 

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.1.38"
+__version__ = "0.1.4"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"

--- a/docs/_docs/examples/index.md
+++ b/docs/_docs/examples/index.md
@@ -19,7 +19,6 @@ want a quick start overview of deid.
  - [Tutorial]({{ site.baseurl }}/examples/recipe)
  - Recipes Files provided as [examples](https://github.com/pydicom/deid/tree/master/examples/deid) or [installed with deid](https://github.com/pydicom/deid/tree/master/deid/data).
 
-
 ## Header Manipulation
 
  - [Replace with Function]({{ site.baseurl }}/examples/func-replace/) shows how to dynamically replace or update header values from a function.

--- a/docs/_docs/examples/recipe.md
+++ b/docs/_docs/examples/recipe.md
@@ -343,7 +343,7 @@ in a recipe:
 FORMAT dicom
 
 %values cookie_names
-SPLIT PatientID by=" ";minlength=4
+SPLIT PatientID by=" ";minlength=3
 
 %values operator_names
 FIELD startswith:Operator

--- a/docs/_docs/user-docs/index.md
+++ b/docs/_docs/user-docs/index.md
@@ -12,6 +12,7 @@ these pages will help you to use the deid software.
 
  - [Filters]({{ site.baseurl }}/user-docs/recipe-filters/): How to write sections to filter and flag images.
  - [Headers]({{ site.baseurl }}/user-docs/recipe-headers/): How to write header actions to update image headers.
+ - [Groups]({{ site.baseurl }}/user-docs/recipe-groups/): for tags (including fields and values) that can be referenced in headers.
  - [Labels]({{ site.baseurl }}/user-docs/recipe-labels/): can be used to add metadata to your recipes.
 
 ## Client

--- a/docs/_docs/user-docs/recipe-groups.md
+++ b/docs/_docs/user-docs/recipe-groups.md
@@ -1,0 +1,150 @@
+---
+title: Recipe Groups
+category: User Documentation
+order: 4
+---
+
+The [recipe headers]({{ site.baseurl }}/user-docs/recipe-headers/) page taught you
+how to write a recipe that has one or more commands to parse a dicom image header.
+For example, we might have:
+
+```
+FORMAT dicom
+
+%header
+
+ADD PatientIdentityRemoved Yes
+BLANK OrdValue
+KEEP Modality
+REPLACE id var:entity_id
+JITTER StudyDate var:entity_timestamp
+REMOVE ReferringPhysicianName
+```
+
+But what if we want to optimize our parsing by creating custom groups of tags
+that are based on the field names, or the values? This is the intended use
+case for groups - a group is a group of tags, either identified by
+fields or values, for which an action can be applied. For the examples
+below, we will use this sample header provided by [@wetzelj](https://github.com/wetzelj). Thank you!
+
+```
+(0008,0050) : SH   Len: 10     AccessionNumber                Value: [999999999 ]
+(0008,0070) : LO   Len: 8      Manufacturer                   Value: [SIEMENS ]
+(0008,1090) : LO   Len: 22     ManufacturersModelName         Value: [SOMATOM Definition AS+]
+(0009,0010) : LO   Len: 20     PrivateCreator10xx             Value: [SIEMENS CT VA1 DUMMY]
+(0010,0010) : PN   Len: 14     PatientsName                   Value: [SIMPSON^HOMER^J^]
+(0010,0020) : LO   Len: 12     PatientID                      Value: [000991991991 ]
+(0010,1000) : LO   Len: 8      OtherPatientIDs                Value: [E123456]
+(0010,1001) : PN   Len: 8      OtherPatientNames              Value: [E123456]
+(0010,21B0) : LT   Len: 90     AdditionalPatientHistory       Value: [MR SIMPSON LIKES DUFF BEER]
+(0019,1091) : DS   Len: 6      <Unknown Tag>                  Value: [E123456]
+(0019,1092) : DS   Len: 6      <Unknown Tag>                  Value: [M123456]
+```
+
+## Fields
+
+A fields section looks like the following:
+
+```
+FORMAT dicom
+
+%fields patient_info
+FIELD PatientID
+FIELD startswith:OtherPatient
+FIELD endswith:Name
+```
+
+There would be multiple ways to do this (for example you could have used `startswith:Patient` to target both `PatientsName`
+and `PatientID`) but generally this will produce a list of fields that are named "patient_info." Here is the list
+rendered out pretty:
+
+```
+patient_info
+------------
+PatientID
+OtherPatientIDs
+OtherPatientNames
+PatientsName
+```
+
+We can then use this in recipe header sections where we want to apply an action to one or more fields
+as follows:
+
+```
+%header
+
+REPLACE fields:patient_info func:generate_uid
+```
+
+And this reads nicely as "Replace fields defined in patient_info to be the variable 
+I'm defining with the function generate_uid (which should be added to each item 
+after lookup).
+
+This of course means that the actions supported for the `%fields` section includes:
+
+ - **FIELD** reference to a full name of a field, or any parsing of any [expander]({{ site.baseurl }}/examples/header-expanders/).
+
+
+## Values
+
+It could be that you want to generate a list of _values_ extracted from the dicom
+to use as flags for checking other fields. For example, if I know that the Patient's ID
+is in PatiendID, I would want to extract the patient's name from that field,
+and then search across fields looking for any instance of a first or last name.
+This is the purpose of the `%values` group. Instead of defining rules to create
+a list of fields, we write rules to extract values. Let's take a look at an
+example:
+
+```
+%values patient_info
+SPLIT PatientsName splitval='^';minlength='4'
+FIELD PatientID
+FIELD OtherPatientIDs
+```
+
+You'll notice that we have `FIELD` again, but since this is in a `%values`
+section, this is saying "Find the fields Patient ID and Other Patient IDs, and whatever
+_values_ you find there, add to the list `patient_info`." You'll also
+notice that the first line uses a new action `SPLIT`:
+
+```
+SPLIT PatientsName splitval='^';minlength='4'
+```
+
+This action says to start with the field `PatientsName`, split based on the `^` 
+character, and keep results that have a length greater than or equal to 4.
+Let's talk about these actions in detail. Field is the same, but we also have split:
+
+ - **FIELD** refers to the full name of a field, or any parsing of any [expander]({{ site.baseurl }}/examples/header-expanders/). Instead of including these field names, we grab the values from them, and add to our list.
+ - **SPLIT** indicates that we want to apply a split operation to a field (or expansion of fields) and for all, to split by a character (defaults to a space) and take a minimum length (defaults to 1).
+
+The result of the above operation might look like this - and remember that this is a list of values.
+
+```
+patient_info
+------------
+HOMER
+SIMPSON
+```
+
+You could then reference these values for some header action. For example, let's say
+we want to remove any field that contains these identifiers:
+
+```
+%header
+REMOVE values:patient_info
+```
+
+The implication of the above is that we are checking all fields for these values.
+This would be functionally equivalent:
+
+```
+%header
+REMOVE ALL values:patient_info
+```
+
+Or you could chose some other field name, or field expander, if you want to limit
+the removal to some subset.
+
+If you haven't yet, take a look at how at generate a basic [get]({{ sitebase.url }}/getting-started/dicom-get/), 
+which is will get a set of fields and values from your dicom files.

--- a/docs/_docs/user-docs/recipe-groups.md
+++ b/docs/_docs/user-docs/recipe-groups.md
@@ -89,7 +89,7 @@ This of course means that the actions supported for the `%fields` section includ
 
 It could be that you want to generate a list of _values_ extracted from the dicom
 to use as flags for checking other fields. For example, if I know that the Patient's ID
-is in PatiendID, I would want to extract the patient's name from that field,
+is in PatientID, I would want to extract the patient's name from that field,
 and then search across fields looking for any instance of a first or last name.
 This is the purpose of the `%values` group. Instead of defining rules to create
 a list of fields, we write rules to extract values. Let's take a look at an

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -362,7 +362,8 @@ REPLACE InstanceSOPUID var:source_id
 ```
 
 Now that you know how configuration works, you have a few options.
-If you want to write a text file and get going with cleaning your files, you should 
-look at some examples for generating a basic [get]({{ sitebase.url }}/getting-started/dicom-get/), 
-which is will get a set of fields and values from your dicom files. For a full walk through
+You can learn how to define groups of tags based on fields or values in [groups]({{ site.baseurl }}/user-docs/recipe-groups/),
+or if you want to write a text file and get going with cleaning your files, you should 
+look at some examples for generating a basic [get]({{ sitebase.url }}/getting-started/dicom-get/).
+This is the action to get a set of fields and values from your dicom files. For a full walk through
 example with a recipe, see the [recipe example]({{ sitebase.url }}/examples/recipe)

--- a/examples/deid/deid.dicom-groups
+++ b/examples/deid/deid.dicom-groups
@@ -1,0 +1,17 @@
+FORMAT dicom
+
+%values cookie_names
+SPLIT PatientID by="^";minlength=4
+
+%values operator_names
+FIELD startswith:Operator
+
+%fields instance_fields
+FIELD contains:Instance
+
+%header
+
+ADD PatientIdentityRemoved Yes
+REPLACE values:cookie_names var:id
+REPLACE values:operator_names var:source_id
+REMOVE fields:instance_fields


### PR DESCRIPTION
# Description

Related issues: #115

This is the start of work to add the definition of values and fields list to the deid recipe. So far I've:

 - added the functionality to parse a configuration including them
 - added a check for a values or fields prefix to define a field group. The "group.py" file is added to the deid.dicom module to provide functions to drive extractions of fields or values lists. The function to extract fields based on values is added to fields.py
 - added basic documentation about the sections to docs (will need feedback about what needs more when I'm finished)

I haven't tested the second bullet above, and likely will tweak the work based on that.

I still need to:

 - update / write tests for the updated configuration
 - test the deid.dicom-groups file for parsing of the fields and values
 - write more docs for interaction with groups (values, fields)

I will try to work on this a little bit at a time - I'm opening a work in progress PR for now to indicate that this still needs work.