### PR TITLE
fixing bug with checking if list empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
-=======
+ - DicomCleaner empty method does not handle list (0.2.01)
  - refactor to use iterall for all fields (0.2.0)
  - including private tags in parsing (0.1.42)
  - adding filters (contains through missing) for REMOVE (0.1.41)

--- a/deid/dicom/filter.py
+++ b/deid/dicom/filter.py
@@ -154,8 +154,15 @@ def empty(self, field):
     """
     content = self.get(field)
 
+    # Case 1: No content (empty list or none)
+    if not content:
+        return True
+
+    if hasattr(content, "_list"):
+        return len(content) == 0
+
     # This is the case of a data element
-    if not isinstance(content, str):
+    elif not isinstance(content, str):
         content = content.value
 
     if content == "":

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.01"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
This is a quick PR to address issue #128. I suspect that the DicomCleaner warrants a more thorough refactor to account for sequences and private tags, but this will only be possible when we have a solid real world example. This should solve the current bug that we can't parse a list of items to determine not empty. 

Signed-off-by: vsoch <vsochat@stanford.edu>

Related issues: # (issue)
 - #128

Please include a summary of the change(s) and if relevant, any related issues above.