### PR TITLE
adding support for saving 4d series to single png, or exporting animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - ability to save 4d dicom series as animation (0.2.14)
  - adding custom cleaner to specify region fields (0.2.13)
  - bug with replace for tested fields (0.2.12)
  - fixing func args to be kwargs (0.2.11)

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"

--- a/docs/_docs/getting-started/dicom-pixels.md
+++ b/docs/_docs/getting-started/dicom-pixels.md
@@ -236,6 +236,24 @@ but you might choose also `FloatPixelData` or `DoubleFloatPixelData` you can do:
 client.clean(pixel_data_attribute="FloatPixelData")
 ```
 
+Note that if your image is 4D and you try to save PNG, it will choose a random
+channel and a middle slice to save.
+
+```python
+client.save_png()
+WARNING Image detected as 4d, will sample channel 1 and middle Z slice
+```
+
+On the other hand, if you want to save a small animation, as of deid version
+0.2.14 you can do that for 4D images instead:
+
+```python
+client.save_animation()
+WARNING Selecting channel 0 for rendering
+Generating animation...
+'/tmp/deid-clean-10_pezq4/cleaned-echo1.mp4'
+```
+
 <a id="debugging">
 ### Debugging and Important Notes
 


### PR DESCRIPTION
This PR will address #135, specifically allowing for a user with a 4d timeseries to:

 - export a single png of a randomly selected, central slice (and random channel)
 - export an animation sequence, again for a random channel (in grayscale) with the temporal dimension moving across the 3d image. 

You can reproduce or test this as follows (from ipython)

```python
cd echo/                                                                                                           
from deid.dicom import DicomCleaner                                                                                
client = DicomCleaner()                                                                                            
WARNING No specification, loading default base deid.dicom

client.detect('echo1.dcm')                                                                                         
 {'flagged': True,
 'results': [{'reason': ' SequenceOfUltrasoundRegions present ',
   'group': 'graylist',
   'coordinates': ['231,70,784,657']},
  {'reason': 'and ImageType contains RECONSTRUCTION|SECONDARY|DERIVED',
   'group': 'graylist',
   'coordinates': []},
  {'reason': 'and ImageType contains DERIVED|SECONDARY|SCREEN SAVE|VOLREN|VXTL STATE',
   'group': 'graylist',
   'coordinates': []},
  {'reason': 'and ImageType contains DERIVED|SECONDARY|SCREEN|SAVE',
   'group': 'blacklist',
   'coordinates': []}]}

client.clean()                                                                                                     
Scrubbing echo1.dcm.
WARNING Updating dicom.PhotometricInterpretation to RGB, set fix_interpretation to False to skip.

client.save_animation()                                                                                            
WARNING Selecting channel 0 for rendering
Generating animation...
'/tmp/deid-clean-10_pezq4/cleaned-echo1.mp4'

client.save_png()
```