### PR TITLE
Bug fix for header adds after deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - bug with multiple actions on the same header field [#140](https://github.com/pydicom/deid/issues/140) (0.2.15)
  - nested sequence in replace_identifiers/strip_sequences bug [#137](https://github.com/pydicom/deid/issues/137) (0.2.14)
  - adding custom cleaner to specify region fields (0.2.13)
  - bug with replace for tested fields (0.2.12)

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -164,6 +164,7 @@ class DicomParser:
         parent, desired = self.get_nested_field(field, return_parent=True)
         if parent and desired in parent:
             del parent[desired]
+            del self.fields[field.uid]
 
     def blank_field(self, field):
         """Blank a field"""
@@ -345,7 +346,12 @@ class DicomParser:
 
         # Otherwise, these are operations on existing fields
         else:
-            for uid, field in fields.items():
+            """ clone the fields dictionary. delete actions must also delete from the fields dictionary.
+                performing the clone and iterating on the clone allows the deletions while preventing a
+                runtime error - "dictionary changed size during iterations"
+            """
+            temp_fields = dict(fields)
+            for uid, field in temp_fields.items():
                 self._run_action(field=field, action=action, value=value)
 
     def add_field(self, field, value):

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -43,6 +43,7 @@ from deid.utils import parse_value, read_json
 
 import os
 import re
+from copy import deepcopy
 
 here = os.path.dirname(os.path.abspath(__file__))
 
@@ -350,7 +351,7 @@ class DicomParser:
                 performing the clone and iterating on the clone allows the deletions while preventing a
                 runtime error - "dictionary changed size during iterations"
             """
-            temp_fields = dict(fields)
+            temp_fields = deepcopy(fields)
             for uid, field in temp_fields.items():
                 self._run_action(field=field, action=action, value=value)
 

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -649,7 +649,7 @@ class TestDicom(unittest.TestCase):
 
         actions = [
             {"action": "JITTER", "field": "StudyDate", "value": "1"},
-            {"action": "JITTER", "field": "StudyDate", "value": "2"}
+            {"action": "JITTER", "field": "StudyDate", "value": "2"},
         ]
         recipe = create_recipe(actions)
         result = replace_identifiers(
@@ -680,7 +680,7 @@ class TestDicom(unittest.TestCase):
 
         actions = [
             {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yeppers!"},
-            {"action": "REMOVE", "field": "PatientIdentityRemoved"}
+            {"action": "REMOVE", "field": "PatientIdentityRemoved"},
         ]
         recipe = create_recipe(actions)
         result = replace_identifiers(
@@ -712,7 +712,7 @@ class TestDicom(unittest.TestCase):
 
         actions = [
             {"action": "REMOVE", "field": "PatientID"},
-            {"action": "ADD", "field": "PatientID", "value": "123456"}
+            {"action": "ADD", "field": "PatientID", "value": "123456"},
         ]
         recipe = create_recipe(actions)
         result = replace_identifiers(

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -633,6 +633,100 @@ class TestDicom(unittest.TestCase):
         for tag in result[0]:
             self.assertFalse(isinstance(tag.value, Sequence))
 
+    def test_jitter_compounding(self):
+        """
+        Testing jitter compounding: Checks to ensure that multiple jitter rules applied to the same field result
+        in both rules being applied. While in practice this may be somewhat of a nonsensical use case when large recipes
+        exist multiple rules may inadvertently be defined.  In prior versions of pydicom/deid rules were additive and 
+        recipes are built in that manner.  This test ensures consistency with prior versions.
+
+        %header
+        JITTER StudyDate 1
+        JITTER StudyDate 2
+        """
+        print("Test jitter compounding")
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "JITTER", "field": "StudyDate", "value": "2"}
+        ]
+        recipe = create_recipe(actions)
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=False,
+            remove_private=False,
+            strip_sequences=True,
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(151, len(result[0]))
+        self.assertEqual("20230104", result[0]["StudyDate"].value)
+
+    def test_addremove_compounding(self):
+        """
+        Testing add/remove compounding: Checks to ensure that multiple rules applied to the same field result
+        in both rules being applied. While in practice this may be somewhat of a nonsensical use case when large recipes
+        exist multiple rules may inadvertently be defined.  In prior versions of pydicom/deid rules were additive and 
+        recipes are built in that manner.  This test ensures consistency with prior versions.
+
+        %header
+        ADD PatientIdentityRemoved Yeppers!
+        REMOVE PatientIdentityRemoved
+        """
+        print("Test addremove compounding")
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yeppers!"},
+            {"action": "REMOVE", "field": "PatientIdentityRemoved"}
+        ]
+        recipe = create_recipe(actions)
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=False,
+            remove_private=False,
+            strip_sequences=True,
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(151, len(result[0]))
+        with self.assertRaises(KeyError):
+            willerror = result[0]["PatientIdentityRemoved"].value
+
+    def test_removeadd_compounding(self):
+        """
+        Testing remove/add compounding: Checks to ensure that multiple rules applied to the same field result
+        in both rules being applied. While in practice this may be somewhat of a nonsensical use case when large recipes
+        exist multiple rules may inadvertently be defined.  In prior versions of pydicom/deid rules were additive and 
+        recipes are built in that manner.  This test ensures consistency with prior versions.
+
+        %header
+        REMOVE StudyDate
+        ADD StudyDate 20200805
+        """
+        print("Test remove/add compounding")
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "PatientID"},
+            {"action": "ADD", "field": "PatientID", "value": "123456"}
+        ]
+        recipe = create_recipe(actions)
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=False,
+            remove_private=False,
+            strip_sequences=True,
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(151, len(result[0]))
+        self.assertEqual("123456", result[0]["PatientID"].value)
+
     # MORE TESTS NEED TO BE WRITTEN TO TEST SEQUENCES
 
 

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.14"
+__version__ = "0.2.15"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: # 140

Corrected issue occurring when a ADD action occurs after a REMOVE action.  Previously, the REMOVE would delete the tag from the header, but the field would remain in the fields list.  This created an issue with subsequent ADD actions due to the fact that the item would be found in the fields dictionary and would be treated as a replace. After correcting this issue by removing the item from the fields list, it introduced an issue when iterating over the fields dictionary while processing multiple-field actions. To accommodate this the iteration over the fields dictionary was switched to a clone so that the dictionary on which we are iterating would not be changed by potential REMOVE actions. 

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
