### PR TITLE
Fix/compound filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)
  - fixes to detect and clean to better represent keep/coordinates (0.2.20)
  - modify default VR for added tags [#146](https://github.com/pydicom/deid/issues/146), bug with private tags in %fields section [#147](https://github.com/pydicom/deid/issues/147) (0.2.19)
  - adding keepcoordinates to allow for reverse specified coordinates (0.2.18)

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -142,9 +142,9 @@ def _has_burned_pixels_single(dicom_file, force, deid):
                 group_descriptions = [item.get("name", "")]
 
             else:
+                group_flags = []  # evaluation for a single line
+                group_descriptions = []
                 for group in item["filters"]:
-                    group_flags = []  # evaluation for a single line
-                    group_descriptions = []
 
                     # You cannot pop from the list
                     for a in range(len(group["action"])):

--- a/deid/tests/resources/filter_multiple_first_filter_match.dicom
+++ b/deid/tests/resources/filter_multiple_first_filter_match.dicom
@@ -1,0 +1,16 @@
+FORMAT dicom
+
+%filter ShouldMatch
+
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains Modality DX
+  + contains Manufacturer Agfa
+
+%filter ShouldNotMatch
+
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
+  contains PatientSex F
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_multiple_rule_innerop_false.dicom
+++ b/deid/tests/resources/filter_multiple_rule_innerop_false.dicom
@@ -1,0 +1,10 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality CT + contains PatientSex F
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_multiple_rule_innerop_false.dicom
+++ b/deid/tests/resources/filter_multiple_rule_innerop_false.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
   contains Modality CT + contains PatientSex F
   + contains Manufacturer Agfa
 

--- a/deid/tests/resources/filter_multiple_rule_innerop_true.dicom
+++ b/deid/tests/resources/filter_multiple_rule_innerop_true.dicom
@@ -1,0 +1,10 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality DX + contains PatientSex M
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_multiple_rule_innerop_true.dicom
+++ b/deid/tests/resources/filter_multiple_rule_innerop_true.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
   contains Modality DX + contains PatientSex M
   + contains Manufacturer Agfa
 

--- a/deid/tests/resources/filter_multiple_second_filter_match.dicom
+++ b/deid/tests/resources/filter_multiple_second_filter_match.dicom
@@ -1,0 +1,16 @@
+FORMAT dicom
+
+%filter ShouldNotMatch
+
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains Modality MR
+  + contains Manufacturer Agfa
+
+%filter ShouldMatch
+
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
+  contains PatientSex M
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_multiple_two_filter_match.dicom
+++ b/deid/tests/resources/filter_multiple_two_filter_match.dicom
@@ -1,0 +1,14 @@
+FORMAT dicom
+
+%filter ShouldMatch1
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains Modality DX
+  + contains Manufacturer Agfa
+
+%filter ShouldMatch2
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains PatientSex M
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_multiple_zero_filter_match.dicom
+++ b/deid/tests/resources/filter_multiple_zero_filter_match.dicom
@@ -1,0 +1,16 @@
+FORMAT dicom
+
+%filter ShouldNotMatch1
+
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains Modality MR
+  + contains Manufacturer Agfa
+
+%filter ShouldNotMatch2
+
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
+  contains PatientSex F
+  + contains Manufacturer Agfa
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_single_rule_false.dicom
+++ b/deid/tests/resources/filter_single_rule_false.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
   contains Modality CT
 
 %header

--- a/deid/tests/resources/filter_single_rule_false.dicom
+++ b/deid/tests/resources/filter_single_rule_false.dicom
@@ -1,0 +1,9 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality CT
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_single_rule_innerop_false.dicom
+++ b/deid/tests/resources/filter_single_rule_innerop_false.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
   contains Modality CT + contains PatientSex F
 
 %header

--- a/deid/tests/resources/filter_single_rule_innerop_false.dicom
+++ b/deid/tests/resources/filter_single_rule_innerop_false.dicom
@@ -1,0 +1,9 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality CT + contains PatientSex F
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_single_rule_innerop_true.dicom
+++ b/deid/tests/resources/filter_single_rule_innerop_true.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
   contains Modality DX + contains PatientSex M
 
 %header

--- a/deid/tests/resources/filter_single_rule_innerop_true.dicom
+++ b/deid/tests/resources/filter_single_rule_innerop_true.dicom
@@ -1,0 +1,9 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality DX + contains PatientSex M
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/resources/filter_single_rule_true.dicom
+++ b/deid/tests/resources/filter_single_rule_true.dicom
@@ -2,7 +2,7 @@ FORMAT dicom
 
 %filter blacklist
 
-LABEL Modality
+LABEL - To be tested with Cat.dcm.  Intended to flag the image.
   contains Modality DX
 
 %header

--- a/deid/tests/resources/filter_single_rule_true.dicom
+++ b/deid/tests/resources/filter_single_rule_true.dicom
@@ -1,0 +1,9 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL Modality
+  contains Modality DX
+
+%header
+ADD PatientIdentityRemoved No 

--- a/deid/tests/test_filter_detect.py
+++ b/deid/tests/test_filter_detect.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+Test Filter Detection
+Copyright (c) 2016-2020 Vanessa Sochat
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import unittest
+import tempfile
+import shutil
+import json
+import os
+import numpy as np
+
+from deid.utils import get_installdir
+from deid.data import get_dataset
+from deid.dicom.parser import DicomParser
+from deid.dicom import get_identifiers, replace_identifiers
+from pydicom import read_file
+from pydicom.sequence import Sequence
+
+from collections import OrderedDict
+
+
+class TestFilterDetect(unittest.TestCase):
+    def setUp(self):
+        self.pwd = get_installdir()
+        self.deidpath = os.path.abspath("%s/tests/resources/" % self.pwd)
+        self.dataset = get_dataset("animals")
+        self.tmpdir = tempfile.mkdtemp()
+        print("\n######################START######################")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        print("\n######################END########################")
+
+    def test_filter_single_rule_false(self):
+        """Test the DicomCleaner.detect to ensure a single rule evaluated to false detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_single_rule_false.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertFalse(out["flagged"])
+
+    def test_filter_single_rule_true(self):
+        """Test the DicomCleaner.detect to ensure a single rule evaluated to true detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_single_rule_true.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+    def test_filter_single_rule_innerop_false(self):
+        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to false detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_single_rule_innerop_false.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertFalse(out["flagged"])
+
+    def test_filter_single_rule_innerop_true(self):
+        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to true detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_single_rule_innerop_true.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+    def test_filter_multiple_rule_innerop_false(self):
+        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to false detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_rule_innerop_false.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertFalse(out["flagged"])
+
+    def test_filter_multple_rule_innerop_true(self):
+        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to true detects appropriately.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_rule_innerop_true.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+
+def get_file(dataset):
+    """helper to get a dicom file"""
+    from deid.dicom import get_files
+
+    dicom_files = get_files(dataset)
+    return next(dicom_files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deid/tests/test_filter_detect.py
+++ b/deid/tests/test_filter_detect.py
@@ -50,8 +50,7 @@ class TestFilterDetect(unittest.TestCase):
         print("\n######################END########################")
 
     def test_filter_single_rule_false(self):
-        """Test the DicomCleaner.detect to ensure a single rule evaluated to false detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure a single rule evaluated to false detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -62,8 +61,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertFalse(out["flagged"])
 
     def test_filter_single_rule_true(self):
-        """Test the DicomCleaner.detect to ensure a single rule evaluated to true detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure a single rule evaluated to true detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -74,8 +72,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertTrue(out["flagged"])
 
     def test_filter_single_rule_innerop_false(self):
-        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to false detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to false detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -86,8 +83,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertFalse(out["flagged"])
 
     def test_filter_single_rule_innerop_true(self):
-        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to true detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to true detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -98,8 +94,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertTrue(out["flagged"])
 
     def test_filter_multiple_rule_innerop_false(self):
-        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to false detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to false detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -110,8 +105,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertFalse(out["flagged"])
 
     def test_filter_multple_rule_innerop_true(self):
-        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to true detects appropriately.
-        """
+        """Test the DicomCleaner.detect to ensure multiple rules within a filter evaluated to true detects appropriately."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -122,8 +116,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertTrue(out["flagged"])
 
     def test_filter_multiple_two_filter_match(self):
-        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
-        """
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -142,8 +135,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertIn("ShouldMatch2", matchgroups)
 
     def test_filter_multiple_zero_filter_match(self):
-        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately not detected when they shouldn't match.
-        """
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately not detected when they shouldn't match."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -162,8 +154,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertNotIn("ShouldNotMatch2", matchgroups)
 
     def test_filter_multiple_first_filter_match(self):
-        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
-        """
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -182,8 +173,7 @@ class TestFilterDetect(unittest.TestCase):
         self.assertNotIn("ShouldNotMatch", matchgroups)
 
     def test_filter_multiple_second_filter_match(self):
-        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
-        """
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected."""
         from deid.dicom import DicomCleaner
 
         dicom_file = get_file(self.dataset)
@@ -212,4 +202,3 @@ def get_file(dataset):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/deid/tests/test_filter_detect.py
+++ b/deid/tests/test_filter_detect.py
@@ -121,6 +121,86 @@ class TestFilterDetect(unittest.TestCase):
         out = client.detect(dicom_file)
         self.assertTrue(out["flagged"])
 
+    def test_filter_multiple_two_filter_match(self):
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_two_filter_match.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+        matchgroups = set()
+
+        for r in out["results"]:
+            matchgroups.add(r["group"])
+
+        self.assertIn("ShouldMatch1", matchgroups)
+        self.assertIn("ShouldMatch2", matchgroups)
+
+    def test_filter_multiple_zero_filter_match(self):
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately not detected when they shouldn't match.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_zero_filter_match.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertFalse(out["flagged"])
+
+        matchgroups = set()
+
+        for r in out["results"]:
+            matchgroups.add(r["group"])
+
+        self.assertNotIn("ShouldNotMatch1", matchgroups)
+        self.assertNotIn("ShouldNotMatch2", matchgroups)
+
+    def test_filter_multiple_first_filter_match(self):
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_first_filter_match.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+        matchgroups = set()
+
+        for r in out["results"]:
+            matchgroups.add(r["group"])
+
+        self.assertIn("ShouldMatch", matchgroups)
+        self.assertNotIn("ShouldNotMatch", matchgroups)
+
+    def test_filter_multiple_second_filter_match(self):
+        """Test the DicomCleaner.detect to ensure multiple detected filters are appropriately detected.
+        """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_multiple_second_filter_match.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
+        matchgroups = set()
+
+        for r in out["results"]:
+            matchgroups.add(r["group"])
+
+        self.assertIn("ShouldMatch", matchgroups)
+        self.assertNotIn("ShouldNotMatch", matchgroups)
+
 
 def get_file(dataset):
     """helper to get a dicom file"""
@@ -132,3 +212,4 @@ def get_file(dataset):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.20"
+__version__ = "0.2.21"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: #142 

Corrected a bug which caused only the last line of a defined filter to be utilized when using the DICOMCleaner to detect PHI in images.  Added unit test to validate various forms of adding filter rules into the recipe file. 

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
