### PR TITLE
fixing issue #153 that fields are not properly indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Referenced versions in headers are tagged on Github, in parentheses are for pypi
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
  - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
+ - change to return results from detect when recipe does not contain filters [#155](https://github.com/pydicom/deid/issues/155)
  - fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)
  - fixes to detect and clean to better represent keep/coordinates (0.2.20)
  - modify default VR for added tags [#146](https://github.com/pydicom/deid/issues/146), bug with private tags in %fields section [#147](https://github.com/pydicom/deid/issues/147) (0.2.19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
  - fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)
  - fixes to detect and clean to better represent keep/coordinates (0.2.20)
  - modify default VR for added tags [#146](https://github.com/pydicom/deid/issues/146), bug with private tags in %fields section [#147](https://github.com/pydicom/deid/issues/147) (0.2.19)

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -251,7 +251,7 @@ def get_fields(dicom, skip=None, expand_sequences=True, seen=None):
         dataset.uid = getattr(dataset, "uid", None)
 
         # Includes private tags, sequences flattened, non-null values
-        for contender in dataset.iterall():
+        for contender in dataset:
 
             # All items should be data elements, skip based on keyword or tag
             if contender.keyword in skip or str(contender.tag) in skip:

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -121,14 +121,15 @@ def _has_burned_pixels_single(dicom_file, force, deid):
     """
     dicom = read_file(dicom_file, force=force)
 
-    # Load criteria (actions) for flagging
-    filters = deid.get_filters()
-    if not filters:
-        bot.exit("Deid provided does not have %filter, exiting.")
-
     # Return list with lookup as dicom_file
     results = []
     global_flagged = False
+
+    # Load criteria (actions) for flagging
+    filters = deid.get_filters()
+    if not filters:
+        bot.warning("Deid provided does not have %filter.")
+        return {"flagged": global_flagged, "results": results}
 
     for name, items in filters.items():
         for item in items:

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
this leads to an error in replacement of nested fields and top level fields having mixed up references. We fixed this by iterating through the dataset as is, instead of using iterall.

Signed-off-by: vsoch <vsochat@stanford.edu>

# Description

Related issues: #153 

Please include a summary of the change(s) and if relevant, any related issues above.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project

# Open questions

Questions that require more discussion or to be addressed in future development:
