### PR TITLE
removing extra verbosity of loading deid recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - removing verbosity of debug logger (0.2.23)
  - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
  - change to return results from detect when recipe does not contain filters [#155](https://github.com/pydicom/deid/issues/155)
  - fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)

--- a/deid/config/__init__.py
+++ b/deid/config/__init__.py
@@ -35,8 +35,6 @@ from deid.logger import bot
 import os
 import re
 
-bot.level = 3
-
 
 class DeidRecipe:
     """Create and work with a deid recipe to filter and perform operations on
@@ -61,7 +59,6 @@ class DeidRecipe:
 
         # If deid is None, use the default
         if deid is None:
-            bot.warning("No specification, loading default base deid.%s" % default_base)
             base = True
 
         self._init_deid(deid, base=base, default_base=default_base)

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -131,6 +131,10 @@ def replace_identifiers(
     if not isinstance(dicom_files, list):
         dicom_files = [dicom_files]
 
+    # Warn the user that we use the default deid recipe
+    if not deid:
+        bot.warning("No deid specification provided, will use defaults.")
+
     # ids (a lookup) is not required
     ids = ids or {}
 

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.22"
+__version__ = "0.2.23"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
Signed-off-by: vsoch <vsochat@stanford.edu>

# Description

This is a suggested solution to address #158 and #157. The warning is moved to the higher level function where it's needed, and removed from the DeidRecipe. The "hard coded" level of 3 is also removed from the `config/__init__.py`

Related issues: #157 #158 

Please include a summary of the change(s) and if relevant, any related issues above.