### PR TITLE
adding stop_before_pixels to read_file of dicom parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - adding stop_before_pixels to read_file in parser (0.2.24)
  - removing verbosity of debug logger (0.2.23)
  - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
  - change to return results from detect when recipe does not contain filters [#155](https://github.com/pydicom/deid/issues/155)

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -44,7 +44,12 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_identifiers(
-    dicom_files, force=True, config=None, strip_sequences=False, remove_private=False
+    dicom_files,
+    force=True,
+    config=None,
+    strip_sequences=False,
+    remove_private=False,
+    stop_before_pixels=False,
 ):
     """extract all identifiers from a dicom image.
     This function returns a lookup by file name, where each value indexed
@@ -74,7 +79,9 @@ def get_identifiers(
 
     # Parse each dicom file
     for dicom_file in dicom_files:
-        parser = DicomParser(dicom_file, force=force)
+        parser = DicomParser(
+            dicom_file, force=force, stop_before_pixels=stop_before_pixels
+        )
         lookup[parser.dicom_file] = parser.get_fields()
 
     return lookup

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -79,7 +79,7 @@ class DicomParser:
     def __repr__(self):
         return self.__str__()
 
-    def load(self, dicom_file, force=True):
+    def load(self, dicom_file, force=True, stop_before_pixels=False):
         """Ensure that the dicom file exists, and use full path. Here
         we load the file, and save the dicom, dicom_file, and dicom_name.
         """
@@ -94,7 +94,9 @@ class DicomParser:
             # If we must read the file, the path must exist
             if not os.path.exists(dicom_file):
                 bot.exit("%s does not exist." % dicom_file)
-            self.dicom = read_file(dicom_file, force=force)
+            self.dicom = read_file(
+                dicom_file, force=force, stop_before_pixels=stop_before_pixels
+            )
 
         # Set class variables that might be helpful later
         self.dicom_file = os.path.abspath(self.dicom.filename)

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.23"
+__version__ = "0.2.24"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
Signed-off-by: vsoch <vsochat@stanford.edu>

# Description

Adding stop_before_pixels to the Parser, to be used by get_identifiers

Related issues: #163 

# Open questions

 - is this supported across versions of pydicom?
 - are there other read_file parameters that might want to be passed, so we should ask for a dictionary of arguments instead?
 - are there other instances of read_file that a user might want this added to?
 - should the default be False?