### PR TITLE
Fix - Multivalued fields in %values lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - bug fix for multivalued fields in %values lists [#174](https://github.com/pydicom/deid/issues/174) (0.2.25)
  - change to correct issue with deidentifying RGB images [#165](https://github.com/pydicom/deid/issues/165) (0.2.24)
  - removing verbosity of debug logger (0.2.23)
  - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)

--- a/deid/dicom/groups.py
+++ b/deid/dicom/groups.py
@@ -56,7 +56,7 @@ def extract_values_list(dicom, actions, fields=None):
         if action["action"] == "FIELD":
             for uid, field in subset.items():
                 if field.element.value not in ["", None]:
-                    if type(field.element.value) is MultiValue:
+                    if isinstance(field.element.value, MultiValue):
                         values.update(field.element.value)
                     else:
                         values.add(field.element.value)

--- a/deid/dicom/groups.py
+++ b/deid/dicom/groups.py
@@ -28,6 +28,7 @@ SOFTWARE.
 from deid.logger import bot
 from .tags import remove_sequences
 from .fields import get_fields, expand_field_expression
+from pydicom.multival import MultiValue
 
 import os
 
@@ -55,7 +56,10 @@ def extract_values_list(dicom, actions, fields=None):
         if action["action"] == "FIELD":
             for uid, field in subset.items():
                 if field.element.value not in ["", None]:
-                    values.add(field.element.value)
+                    if type(field.element.value) is MultiValue:
+                        values.update(field.element.value)
+                    else:
+                        values.add(field.element.value)
 
         # Split action, can optionally have a "by" and/or minlength parameter
         elif action["action"] == "SPLIT":

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.24"
+__version__ = "0.2.25"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: #174 

Checked value before attempting to add it to values list.  If the value is MultiValue, use set.Update() instead of set.Add().

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
None
