### PR TITLE
Updated pydicom dependency from 1.3.0 to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - bug fix for multivalued fields in %values lists [#174](https://github.com/pydicom/deid/issues/174) (0.2.25)
+ - updated pydicom dependency from 1.3.0 to 2.1.1 [#171] (https://github.com/pydicom/deid/issues/171), bug fix for multivalued fields in %values lists [#174](https://github.com/pydicom/deid/issues/174) (0.2.25)
  - change to correct issue with deidentifying RGB images [#165](https://github.com/pydicom/deid/issues/165) (0.2.24)
  - removing verbosity of debug logger (0.2.23)
  - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)

--- a/deid/version.py
+++ b/deid/version.py
@@ -34,6 +34,6 @@ LICENSE = "LICENSE"
 INSTALL_REQUIRES = (
     ("matplotlib", {"min_version": None}),
     ("numpy", {"min_version": None}),
-    ("pydicom", {"exact_version": "1.3.0"}),
+    ("pydicom", {"exact_version": "2.1.1"}),
     ("python-dateutil", {"min_version": None}),
 )


### PR DESCRIPTION
# Description

Related issues: #171 
Updated required pydicom version from 1.3.0 to 2.1.1

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

None
