### PR TITLE
Add codespell to CI to catch typos early

### DIFF
--- a/.github/codespell_ignore_words.txt
+++ b/.github/codespell_ignore_words.txt
@@ -1,0 +1,4 @@
+nd
+ot
+searchin
+som

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,17 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@de089481bd65b71b4d02e34ffb3566b6d189333e

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+
+[codespell]
+skip = lunr.min.js
+ignore-words = .github/codespell_ignore_words.txt


### PR DESCRIPTION
# Description

Run [codespell](https://github.com/codespell-project/codespell) in CI to catch typos early on.

Use GitHub Actiosn with [actions-codespell](https://github.com/codespell-project/actions-codespell).

Related PR: #185

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] My code follows the style guidelines of this project