### PR TITLE
updated pydicom dependency from 2.1.1 to 2.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build
 pypi.sh
 
 private
+# dev tools
+.idea
 .vscode
 
 # osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - updated pydicom dependency from 2.1.1 to 2.2.2 [#194](https://github.com/pydicom/deid/issues/194)
  - various LGTM alert fixes [#186](https://github.com/pydicom/deid/pull/186)
  - bug fix for exception when attempting to jitter DA/DT which cannot be jittered (space) [#189] (https://github.com/pydicom/deid/issues/189) (0.2.27)
  - adding support to manipulate file meta [#183](https://github.com/pydicom/deid/issues/183) (0.2.26)

--- a/deid/version.py
+++ b/deid/version.py
@@ -34,6 +34,6 @@ LICENSE = "LICENSE"
 INSTALL_REQUIRES = (
     ("matplotlib", {"min_version": None}),
     ("numpy", {"min_version": None}),
-    ("pydicom", {"exact_version": "2.1.1"}),
+    ("pydicom", {"exact_version": "2.2.2"}),
     ("python-dateutil", {"min_version": None}),
 )


### PR DESCRIPTION
#193 'bump pydicom' - bumped to 2.2.2, local tests green, added PyCharm to gitignore

# Description
`deid` was locked to `2.1.1`, but latest is `2.2.2` with some features and bugfixes is available. Lets bump!
Also minor addition to gitignore.
Related issues: # (issue)
#193
# Checklist

- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [x ] My code follows the style guidelines of this project


# Open questions
How could we test changes? I.e. update to DICOM dictionary 2021d
