### PR TITLE
WIP+ENH: Add REMAP action for automatically remapping (instance) UIDs

### DIFF
--- a/deid/config/standards.py
+++ b/deid/config/standards.py
@@ -29,7 +29,7 @@ formats = ["dicom"]
 sections = ["header", "labels", "filter", "values", "fields"]
 
 # Supported Header Actions
-actions = ("ADD", "BLANK", "JITTER", "KEEP", "REPLACE", "REMOVE", "LABEL")
+actions = ("ADD", "BLANK", "JITTER", "KEEP", "REPLACE", "REMOVE", "REMAP", "LABEL")
 
 # Supported Group actions (SPLIT only supported for values)
 groups = ["values", "fields"]

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -568,7 +568,7 @@ def parse_config_action(section, line, config, section_name=None):
             config[section].append({"action": action, "field": field, "value": value})
 
     # Actions that don't require a value
-    elif action in ["BLANK", "KEEP"]:
+    elif action in ["BLANK", "KEEP", "REMAP"]:
         bot.debug("%s: adding %s" % (section, line))
         config[section].append({"action": action, "field": field})
 

--- a/deid/data/deid.dicom
+++ b/deid/data/deid.dicom
@@ -745,6 +745,7 @@ LABEL Burned In Annotation # (CTP)
 
 %header
 
+REMAP contains:((?<!SOPClass)UID)
 REMOVE endswith:Time
 REMOVE endswith:Date
 REMOVE endswith:time
@@ -765,8 +766,7 @@ REMOVE PatientsName
 REMOVE ReasonForStudy
 REMOVE contains:Trial
 REMOVE startswith:PatientTelephoneNumber
-REMOVE endswith:ID
-REMOVE endswith:IDs
+REMOVE contains:([^U]IDs?)
 REMOVE ReferringPhysicianName
 REMOVE ConsultingPhysicianName
 REMOVE EvaluatorName
@@ -799,7 +799,6 @@ REMOVE SourceApplicatorName
 REMOVE ClinicalTrialSponsorName
 REMOVE ContentCreatorName
 REMOVE ClinicalTrialProtocolEthicsCommitteeName
-REMOVE contains:UID
 REMOVE RegionOfResidence
 REMOVE CurrentPatientLocation
 REMOVE PatientComments

--- a/deid/dicom/actions.py
+++ b/deid/dicom/actions.py
@@ -22,6 +22,8 @@ SOFTWARE.
 
 """
 
+from pydicom.uid import generate_uid
+
 from deid.logger import bot
 from deid.utils import get_timestamp
 
@@ -86,3 +88,20 @@ def jitter_timestamp(field, value):
                 bot.warning("JITTER not supported for %s with VR=%s" % (field, dcmvr))
 
     return new_value
+
+
+# UIDs
+
+def remap_uid(field):
+    """Remap existing UID in stable and secure manner
+    
+    Same input UID creates the same output UID, which keeps study / series
+    associations correct (or even FrameOfReferenceUID) provided the full
+    study / series in anonymized. At same time input UID can't be recovered
+    from output so any potential PHI (i.e. dates / times) is eliminated.
+    """
+    if isinstance(field.value, list):
+        # Handle VM > 1 
+        return [generate_uid(entropy_srcs=[x]) for x in field.value]
+    else:
+        return generate_uid(entropy_srcs=[field.value])

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -35,7 +35,7 @@ from pydicom.dataset import Dataset
 from deid.config import DeidRecipe
 from deid.config.standards import actions as valid_actions
 from deid.dicom.utils import save_dicom
-from deid.dicom.actions import jitter_timestamp
+from deid.dicom.actions import jitter_timestamp, remap_uid
 from deid.dicom.tags import remove_sequences, get_private, get_tag, add_tag
 from deid.dicom.groups import extract_values_list, extract_fields_list
 from deid.dicom.fields import get_fields, expand_field_expression, DicomField
@@ -445,6 +445,7 @@ class DicomParser:
         Both result in a call to this function. If an action fails or is not
         done, None is returned, and the calling function should handle this.
         """
+        
         # Blank the value
         if action == "BLANK":
             self.blank_field(field)
@@ -469,6 +470,14 @@ class DicomParser:
                     self.replace_field(field, new_val)
             else:
                 bot.warning("JITTER %s unsuccessful" % field)
+
+        # Remap UIDs
+        elif action == "REMAP":
+            if field.element.VR == 'UI':
+                new_val = remap_uid(field.element)
+            else:
+                bot.warning("REMAP called on invalid (non-UID) element %s" % field)
+            self.replace_field(field, new_val)
 
         # elif "KEEP" --> Do nothing. Keep the original
 

--- a/deid/tests/test_config.py
+++ b/deid/tests/test_config.py
@@ -88,6 +88,7 @@ class TestConfig(unittest.TestCase):
             "KEEP",
             "REPLACE",
             "REMOVE",
+            "REMAP",
             "JITTER",
             "LABEL",
         ]

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -360,6 +360,37 @@ class TestDicom(unittest.TestCase):
             "20230102011721.621000", result[0]["AcquisitionDateTime"].value
         )
 
+    def test_remap_uid(self):
+
+        print("Test uid remapping")
+        dicom_file = get_file(self.dataset)
+        dicom = read_file(dicom_file)
+        orig_uid = dicom.StudyInstanceUID
+
+        actions = [{"action": "REMAP", "field": "StudyInstanceUID"}]
+        recipe = create_recipe(actions)
+
+        result1 = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=False,
+            remove_private=False,
+            strip_sequences=False,
+        )
+        self.assertEqual(1, len(result1))
+        self.assertNotEqual(
+            orig_uid, result1[0]["StudyInstanceUID"].value
+        )
+        result2 = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=False,
+            remove_private=False,
+            strip_sequences=False,
+        )
+        self.assertEqual(1, len(result2))
+        self.assertEqual(result1[0]["StudyInstanceUID"].value, result2[0]["StudyInstanceUID"].value)
+
     def test_expanders(self):
         """RECIPE RULES
         REMOVE contains:Collimation


### PR DESCRIPTION
# Description

This PR improves (instance) UID handling by allowing them to be automatically remapped through a new "REMAP" action. The new UIDs are created in a way that strips all PHI (usually timestamps embedded into the UID) while preserving the study/series hierarchy (defined by the UIDs) in the anonymized output. This allows the anonymized data to be(for example) uploaded to a PACS or other network entity.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

I also updated the default recipe to handle UIDs in this way, if you prefer I don't do that (at least for now) let me know.
