### PR TITLE
#197 'remove and replace/jitter combo' - added once-evaluated list of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - `ADD/KEEP` actions have now higher priority than `KEEP`, allowing to whitelist fields from `REMOVE ALL` [#197](https://github.com/pydicom/deid/issues/197)
+ - `REPLACE/JITTER` actions have now higher priority than `REMOVE`, allowing to whitelist fields from `REMOVE ALL/Field` [#197](https://github.com/pydicom/deid/issues/197)
+ - `ADD/KEEP` actions have now higher priority than `REMOVE`, allowing to whitelist fields from `REMOVE ALL/Field` [#197](https://github.com/pydicom/deid/issues/197)
  - updated pydicom dependency from 2.1.1 to 2.2.2 [#194](https://github.com/pydicom/deid/issues/194)
  - various LGTM alert fixes [#186](https://github.com/pydicom/deid/pull/186)
  - bug fix for exception when attempting to jitter DA/DT which cannot be jittered (space) [#189] (https://github.com/pydicom/deid/issues/189) (0.2.27)

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -301,7 +301,10 @@ class DicomParser:
             if self.recipe.deid is not None:
                 self._excluded_fields = [
                     action.get("field")
-                    for action in (self.recipe.get_actions(action="JITTER") + self.recipe.get_actions(action="REPLACE"))
+                    for action in (
+                        self.recipe.get_actions(action="JITTER")
+                        + self.recipe.get_actions(action="REPLACE")
+                    )
                     if action and action.get("field")
                 ]
         return self._excluded_fields

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -841,6 +841,148 @@ class TestDicom(unittest.TestCase):
         self.assertIsNotNone(parser.dicom["PixelData"])
         self.assertEqual("19700101", parser.dicom["StudyDate"].value)
 
+    def test_remove_all_replace_one_should_replace(self):
+        """
+        %header
+        REMOVE ALL
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_jitter_one_should_jitter(self):
+        """
+        %header
+        REMOVE ALL
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230102", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_keep_one_replace_it_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_keep_one_jitter_it_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_field_replace_it_should_replace(self):
+        """
+        %header
+        REMOVE StudyDate
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "StudyDate"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_field_jitter_it_should_jitter(self):
+        """
+        %header
+        REMOVE StudyDate
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "StudyDate"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230102", parser.dicom["StudyDate"].value)
+
     def test_remove_field_keep_same_field_compounding_should_keep(self):
         """
         %header

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.29rc1"
+__version__ = "0.2.29rc2"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"

--- a/deid/version.py
+++ b/deid/version.py
@@ -22,7 +22,7 @@ SOFTWARE.
 
 """
 
-__version__ = "0.2.29rc2"
+__version__ = "0.3.0"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "deid"

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -219,14 +219,15 @@ be taken on a header field/value:
 
  - ADD: Add a new field to the dataset(s). If the value is a string, it's assumed to be the value that is desired to be added. If the value is in the form `var:OrdValue` then the application will expect to find the value to replace in a variable in the request called `OrdValue` (more on this later).
  - BLANK: If you want to blank a field instead of remove it, use this option. This is the default action.
- - KEEP: implies that the value should not be replaced, removed, or blanked.
+ - KEEP: implies that the value should not be replaced, jittered, removed, or blanked.
  - REPLACE: implies that the value should be replaced by a string, or a variable in the format `var:FieldName`.
- - REMOVE: completely remove the field from the dataset (if not protected by `KEEP` or is in default skip list).
+ - JITTER: implies that the value should be jittered ("deviated") by a string, or a variable in the format `var:FieldName`.
+ - REMOVE: completely remove the field from the dataset (if not protected by `KEEP`, changed by 'REPLACE' or 'JITTER', or is in default skip list).
 
 For the above, given that there are conflicting commands, the more conservative is given preference. For example:
 
 ```
-KEEP > ADD > REMOVE > BLANK > REPLACE > JITTER
+KEEP > ADD > REPLACE > JITTER > REMOVE > BLANK
 ``` 
 
 For example, if I add or keep a header, and then also specify to blank or remove it, 

--- a/examples/dicom/dicom-extract/create-dicom-csv.py
+++ b/examples/dicom/dicom-extract/create-dicom-csv.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 
 def load_tags_in_files(tag_file_path):
     """
-    load tags_in_files reads a csv file containing dicom tags 
+    load tags_in_files reads a csv file containing dicom tags
     and creates a dictionary
 
     Args:
@@ -73,7 +73,7 @@ def get_tags_in_files(dicom_path, tag_file_path):
 def directory_to_csv(dicom_path, csv_file_path, tags_in_files, tags_to_exclude):
     """
     directory_to_csv iterates over a directory, finds dicom files with
-    a .dcm extension and then creates a spreadsheet containing all of 
+    a .dcm extension and then creates a spreadsheet containing all of
     the tag values for the tags in the csv for every dicom file
 
     Args:
@@ -133,10 +133,10 @@ def directory_to_csv(dicom_path, csv_file_path, tags_in_files, tags_to_exclude):
 
 if __name__ == "__main__":
     """
-    Need an easy way to for a person to validate their deidentification worked. 
+    Need an easy way to for a person to validate their deidentification worked.
     This example 1st scans a directory and creates a unique set of dicom tags
     across all files. It then reads the values for all tags in all files and
-    creates a csv file which can be loaded into excel or a database to review. 
+    creates a csv file which can be loaded into excel or a database to review.
     """
     osx = platform.system().lower() == "darwin"
     if osx:

--- a/examples/dicom/header-manipulation/func-replacement.py
+++ b/examples/dicom/header-manipulation/func-replacement.py
@@ -89,9 +89,9 @@ recipe.get_actions(field="PatientID", action="REMOVE")
 
 def generate_uid(item, value, field, dicom):
     """This function will generate a dicom uid! You can expect it to be passed
-       the dictionary of items extracted from the dicom (and your function)
-       and variables, the original value (func:generate_uid) and the field
-       object you are applying it to.
+    the dictionary of items extracted from the dicom (and your function)
+    and variables, the original value (func:generate_uid) and the field
+    object you are applying it to.
     """
     import uuid
 

--- a/examples/dicom/header-manipulation/func-sequence-replace/example.py
+++ b/examples/dicom/header-manipulation/func-sequence-replace/example.py
@@ -22,9 +22,9 @@ recipe = DeidRecipe("deid.dicom")
 
 def generate_date(item, value, field, dicom):
     """This function will generate a dicom uid! You can expect it to be passed
-       the dictionary of items extracted from the dicom (and your function)
-       and variables, the original value (func:generate_uid) and the field
-       object you are applying it to.
+    the dictionary of items extracted from the dicom (and your function)
+    and variables, the original value (func:generate_uid) and the field
+    object you are applying it to.
     """
     return "20200608"
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 
 
 def get_lookup():
-    """get version by way of deid.version, returns a 
+    """get version by way of deid.version, returns a
     lookup dictionary with several global variables without
     needing to import singularity
     """


### PR DESCRIPTION
# Description
Whitelisting was not possible for replacing. Now fields being replaced or jittered are excluded from removal (either `REMOVE ALL` or `REMOVE SomeField`).

It is done using separate property and private variable to keep result (lazy eval). 

Made clarification regarding `KEEP` list - those fields are being removed from field list to process, meaning that `KEEP SomeField` + `REPLACE SomeField ...` won't work, as kept field is being excluded from list of fields to process for other actions. 

Added tests.
Bumped release candidate number and changelog (+small fix for previous change)

Minor docs update.


Related issues: #197 , #198 

Please include a summary of the change(s) and if relevant, any related issues above.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [?] My code follows the style guidelines of this project
- [x] tests added
- [x] documentation updated

# Open questions

codestyle on `excluded_from_deletion` property is discussable, opened for suggestions.
