### PR TITLE
Add vr:XX field expander

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - add vr:XX field expander to select elements by VR (0.2.32)
+ - add vr:XX field expander to select elements by VR (0.2.33)
  - add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)
  - custom class example for using dicom.Dataset, not requiring on client init [#211](https://github.com/pydicom/deid/pull/211) (0.2.31)
  - adding support for deid provided functions [#207](https://github.com/pydicom/deid/issues/207) (0.2.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - add vr:XX field expander to select elements by VR (0.2.32)
  - add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)
  - custom class example for using dicom.Dataset, not requiring on client init [#211](https://github.com/pydicom/deid/pull/211) (0.2.31)
  - adding support for deid provided functions [#207](https://github.com/pydicom/deid/issues/207) (0.2.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - add vr:XX field expander to select elements by VR (0.2.33)
+ - add select:vr:XX field expander to select elements by VR (0.2.33)
+ - rename group:XXXX field expander to select:group:XXXX
  - add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)
  - custom class example for using dicom.Dataset, not requiring on client init [#211](https://github.com/pydicom/deid/pull/211) (0.2.31)
  - adding support for deid provided functions [#207](https://github.com/pydicom/deid/issues/207) (0.2.3)

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -86,17 +86,22 @@ class DicomField:
                 return True
         return False
 
-    def tag_within_group(self, group):
+    def select_matches(self, expression):
         """
-        Determine whether the element tag belongs to a group
+        Determine whether the element has a specific selected attribute
         """
-        return self.element.tag.group == group
+        attribute, value = expression.split(":", 1)
+        attribute = attribute.upper()
 
-    def vr_matches(self, vr):
-        """
-        Determine whether the element has a specific value-representation
-        """
-        return self.element.VR == vr
+        if attribute == "VR":
+            value = value[0:2].upper()
+            return self.element.VR == value
+
+        elif attribute == "GROUP":
+            value = int(value, 16)
+            return self.element.tag.group == value
+
+        return False
 
 
 def extract_item(item, prefix=None, entry=None):
@@ -217,10 +222,6 @@ def expand_field_expression(field, dicom, contenders=None):
         expression = "(%s)$" % expression
     elif expander.lower() == "startswith":
         expression = "^(%s)" % expression
-    elif expander.lower() == "group":
-        expression = int(expression, 16)
-    elif expander.lower() == "vr":
-        expression = expression[0:2].upper()
 
     # Loop through fields, all are strings STOPPED HERE NEED TO ADDRESS EMPTY NAME
     for uid, field in contenders.items():
@@ -234,12 +235,8 @@ def expand_field_expression(field, dicom, contenders=None):
             if not field.name_contains(expression):
                 fields[uid] = field
 
-        elif expander.lower() == "group":
-            if field.tag_within_group(expression):
-                fields[uid] = field
-
-        elif expander.lower() == "vr":
-            if field.vr_matches(expression):
+        elif expander.lower() == "select":
+            if field.select_matches(expression):
                 fields[uid] = field
 
     return fields

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -92,6 +92,12 @@ class DicomField:
         """
         return self.element.tag.group == group
 
+    def vr_matches(self, vr):
+        """
+        Determine whether the element has a specific value-representation
+        """
+        return self.element.VR == vr
+
 
 def extract_item(item, prefix=None, entry=None):
     """
@@ -173,6 +179,7 @@ def expand_field_expression(field, dicom, contenders=None):
     startswith: filter to fields that start with the expression
     contains: filter to fields that contain the expression
     group: filter to fields matching DICOM group
+    vr: filter to elements with a specified VR
     allfields: include all fields
     exceptfields: filter to all fields except those listed ( | separated)
 
@@ -212,6 +219,8 @@ def expand_field_expression(field, dicom, contenders=None):
         expression = "^(%s)" % expression
     elif expander.lower() == "group":
         expression = int(expression, 16)
+    elif expander.lower() == "vr":
+        expression = expression[0:2].upper()
 
     # Loop through fields, all are strings STOPPED HERE NEED TO ADDRESS EMPTY NAME
     for uid, field in contenders.items():
@@ -227,6 +236,10 @@ def expand_field_expression(field, dicom, contenders=None):
 
         elif expander.lower() == "group":
             if field.tag_within_group(expression):
+                fields[uid] = field
+
+        elif expander.lower() == "vr":
+            if field.vr_matches(expression):
                 fields[uid] = field
 
     return fields

--- a/deid/dicom/fields.py
+++ b/deid/dicom/fields.py
@@ -183,8 +183,7 @@ def expand_field_expression(field, dicom, contenders=None):
     endswith: filter to fields that end with the expression
     startswith: filter to fields that start with the expression
     contains: filter to fields that contain the expression
-    group: filter to fields matching DICOM group
-    vr: filter to elements with a specified VR
+    select: filter based on DICOM element properties
     allfields: include all fields
     exceptfields: filter to all fields except those listed ( | separated)
 

--- a/deid/tests/test_dicom_fields.py
+++ b/deid/tests/test_dicom_fields.py
@@ -50,7 +50,7 @@ class TestDicomFields(unittest.TestCase):
 
         print("Testing that field expansion works for groups")
         fields = expand_field_expression(
-            dicom=dicom, field="group:0020", contenders=contenders
+            dicom=dicom, field="select:group:0020", contenders=contenders
         )
 
         # The fields returned should be tag group 0020
@@ -59,7 +59,7 @@ class TestDicomFields(unittest.TestCase):
 
         print("Testing that field expansion works for VR")
         fields = expand_field_expression(
-            dicom=dicom, field="vr:TM", contenders=contenders
+            dicom=dicom, field="select:VR:TM", contenders=contenders
         )
 
         # The fields returned should end in time

--- a/deid/tests/test_dicom_fields.py
+++ b/deid/tests/test_dicom_fields.py
@@ -57,6 +57,16 @@ class TestDicomFields(unittest.TestCase):
         for uid, field in fields.items():
             assert field.element.tag.group == 0x0020
 
+        print("Testing that field expansion works for VR")
+        fields = expand_field_expression(
+            dicom=dicom, field="vr:TM", contenders=contenders
+        )
+
+        # The fields returned should end in time
+        for uid, field in fields.items():
+            assert field.name.endswith("Time")
+            assert field.element.VR == "TM"
+
         print("Testing that we can also search private tags based on numbers.")
         fields = expand_field_expression(
             dicom=dicom, field="contains:0019", contenders=contenders

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -282,8 +282,8 @@ JITTER endswith:Date var:jitter
 
 and this is the idea of an `expander`. And expander is an optional filter 
 applied to a header field (the middle value) to select some subset of header 
-values. Currently, we support `startswith`, `endswith`, `contains`, `group`,
-`vr`, `allexcept`, and `allfields`.
+values. Currently, we support `startswith`, `endswith`, `contains`, `select`,
+`allexcept`, and `allfields`.
  
 The following examples show what fields are selected based on each filter. For
 all examples, the test is done making the values lowercase.
@@ -324,27 +324,35 @@ BLANK contains:Name
 Notice how we get Name in uppercase (when our search string was lowercase) and
 it can appear anywhere in the field.
 
-**group**
+**select**
 
-The `group:` filter selects fields based on their DICOM group. Groups are
-specified as hexadecimal numbers (of up to four digits). For example,
-the following rules will keep all elements contained within DICOM
-groups 0x0018, 0x0020 and 0x0020:
+The `select` filter can be used to select fields based on properties
+of the DICOM element. These filters have the form
+`select:property:value`.
+
+Currently implemented property filters are `select:group:` to select
+elements by tag group and `select:VR:` to select elements by value
+representation.
+
+The `select:group:` filter selects fields based on their DICOM
+group. Groups values for the filter are specified as hexadecimal
+numbers (of up to four digits). For example, the following rules will
+keep all elements contained within DICOM groups 0x0018, 0x0020 and
+0x0020:
 
 ```
-KEEP group:0018
-KEEP group:0020
-KEEP group:0028
+KEEP select:group:0018
+KEEP select:group:0020
+KEEP select:group:0028
 ```
 
-**vr**
-
-The `vr:` filter selects fields based on the value representation (VR)
-of the element. For example, the following rules will blank all
+The `select:VR:` filter selects fields based on the value
+representation (VR) of the element. VR values are specified as the two
+character strings. For example, the following rules will blank all
 elements that have a VR of TM (time):
 
 ```
-BLANK vr:TM
+BLANK select:VR:TM
 ```
 
 **all**

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -283,7 +283,7 @@ JITTER endswith:Date var:jitter
 and this is the idea of an `expander`. And expander is an optional filter 
 applied to a header field (the middle value) to select some subset of header 
 values. Currently, we support `startswith`, `endswith`, `contains`, `group`,
-`allexcept`, and `allfields`.
+`vr`, `allexcept`, and `allfields`.
  
 The following examples show what fields are selected based on each filter. For
 all examples, the test is done making the values lowercase.
@@ -326,7 +326,7 @@ it can appear anywhere in the field.
 
 **group**
 
-The group filter selects fields based on their DICOM group. Groups are
+The `group:` filter selects fields based on their DICOM group. Groups are
 specified as hexadecimal numbers (of up to four digits). For example,
 the following rules will keep all elements contained within DICOM
 groups 0x0018, 0x0020 and 0x0020:
@@ -335,6 +335,16 @@ groups 0x0018, 0x0020 and 0x0020:
 KEEP group:0018
 KEEP group:0020
 KEEP group:0028
+```
+
+**vr**
+
+The `vr:` filter selects fields based on the value representation (VR)
+of the element. For example, the following rules will blank all
+elements that have a VR of TM (time):
+
+```
+BLANK vr:TM
 ```
 
 **all**


### PR DESCRIPTION
# Description

This is adds a vr: field expander that allows fields to be selected by VR. This allows targeting based on content. For example vr:PN will select all Person Name elements. Or vr:TM will select all Time elements without selecting Date Time elements.

Note: endswith:Time will select some fields that are DT (such as AcquisitionDateTime)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions
