### PR TITLE
Add possibility to clean PyDicom objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 .cache
+
+# PyCharm
+.idea/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - Add function to clean datasets without `DicomCleaner` [#223](https://github.com/pydicom/deid/pull/223) (0.2.34)
  - add select:vr:XX field expander to select elements by VR (0.2.33)
  - rename group:XXXX field expander to select:group:XXXX
  - add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)

--- a/deid/dicom/__init__.py
+++ b/deid/dicom/__init__.py
@@ -1,4 +1,4 @@
 from .fields import extract_sequence
 from .header import get_identifiers, remove_private_identifiers, replace_identifiers
-from .pixels import DicomCleaner, has_burned_pixels
+from .pixels import DicomCleaner, has_burned_pixels, clean_pixel_data
 from .utils import get_files

--- a/deid/dicom/pixels/__init__.py
+++ b/deid/dicom/pixels/__init__.py
@@ -1,2 +1,2 @@
-from .clean import DicomCleaner
+from .clean import DicomCleaner, clean_pixel_data
 from .detect import has_burned_pixels

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -2,19 +2,27 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2022, Vanessa Sochat"
 __license__ = "MIT"
 
+
 """
 detect.py: functions for pixel scrubbing
 """
 
-from pydicom import read_file
+from typing import Union, List, Optional
+
+from pydicom import read_file, FileDataset
 from pydicom.sequence import Sequence
 
 from deid.config import DeidRecipe
 from deid.dicom.filter import apply_filter
+from deid.dicom.types import DcmOrStr
 from deid.logger import bot
 
 
-def has_burned_pixels(dicom_files, force=True, deid=None):
+def has_burned_pixels(
+    dicom_files: Union[list[DcmOrStr], DcmOrStr],
+    force: bool = True,
+    deid: Optional[DeidRecipe] = None,
+):
     """has burned pixels is an entrypoint for has_burned_pixels_multi (for
     multiple images) or has_burned_pixels_single (for one detailed repor)
     We will use the MIRCTP criteria (see ref folder with the
@@ -34,7 +42,7 @@ def has_burned_pixels(dicom_files, force=True, deid=None):
     return _has_burned_pixels_single(dicom_files, force, deid)
 
 
-def _has_burned_pixels_multi(dicom_files, force, deid):
+def _has_burned_pixels_multi(dicom_files: List[Union[str, FileDataset]], force, deid):
     """return a summary dictionary with lists of clean, and then lookups
     for flagged images with reasons. The deid should be a deid recipe
     instantiated from deid.config.DeidRecipe. This function should not
@@ -58,7 +66,7 @@ def _has_burned_pixels_multi(dicom_files, force, deid):
     return decision
 
 
-def _has_burned_pixels_single(dicom_file, force, deid):
+def _has_burned_pixels_single(dicom_file: DcmOrStr, force: bool, deid):
 
     """has burned pixels single will evaluate one dicom file for burned in
     pixels based on 'filter' criteria in a deid. If deid is not provided,
@@ -102,7 +110,10 @@ def _has_burned_pixels_single(dicom_file, force, deid):
             ]
         }
     """
-    dicom = read_file(dicom_file, force=force)
+    if isinstance(dicom_file, FileDataset):
+        dicom = dicom_file
+    else:
+        dicom = read_file(dicom_file, force=force)
 
     # Return list with lookup as dicom_file
     results = []

--- a/deid/dicom/types.py
+++ b/deid/dicom/types.py
@@ -1,0 +1,9 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2016-2022, Vanessa Sochat"
+__license__ = "MIT"
+
+from typing import Union
+
+from pydicom import FileDataset
+
+DcmOrStr = Union[str, FileDataset]

--- a/deid/dicom/utils.py
+++ b/deid/dicom/utils.py
@@ -6,10 +6,14 @@ import os
 import tempfile
 import zipfile
 
+import pydicom
+from pydicom import FileDataset
+
 from deid.logger import bot
 from deid.utils import recursive_find
-
+from .types import DcmOrStr
 from .validate import validate_dicoms
+
 
 ################################################################################
 # Functions for Dicom files
@@ -101,3 +105,10 @@ def save_dicom(dicom, dicom_file, output_folder=None, overwrite=False):
     if dowrite:
         dicom.save_as(output_dicom)
     return output_dicom
+
+
+def load_dicom(dcm_file: DcmOrStr) -> FileDataset:
+    if isinstance(dcm_file, FileDataset):
+        return dcm_file
+    else:
+        return pydicom.read_file(dcm_file, force=True)

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2022, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"

--- a/docs/_docs/getting-started/dicom-pixels.md
+++ b/docs/_docs/getting-started/dicom-pixels.md
@@ -341,3 +341,26 @@ client.clean(fix_interpretation=False)
 Please [see the note](https://pydicom.github.io/pydicom/stable/old/image_data_handlers.html#usage)
 on the pydicom documentation for more details. Also, it would be useful to use machine 
 learning to detect text. if you want to develop this or have ideas, please reach out.
+
+<a id="no-client">
+### Usage without the client
+
+There are some cases when using the client won't be handy (multiprocessing) or working on PyDicom files directly would be preferred.
+In that case, you can skip client initialization and do:
+
+```python
+import pydicom
+import matplotlib.pyplot as plt
+
+from deid.dicom.pixels import clean_pixel_data, has_burned_pixels
+
+dicom_file_data = pydicom.read_file(DICOM_FILE)
+
+burned_pixels_results = has_burned_pixels(dicom_file_data)
+cleaned_pixels = clean_pixel_data(
+    dicom_file=dicom_file_data, 
+    results=burned_pixels_results
+)
+
+plt.imshow(cleaned_pixels)
+```


### PR DESCRIPTION
# Description

The point of this PR is to add the possibility to work on PyDicom objects directly, in order to speed up the process. It indeed avoids reading the dicom file from disk twice.

Extracting the `clean_pixel_data` function out of the `DicomCleaner` class also helps when we want to process multiple images in multiple processes without having to instance multiple `DicomCleaner` times (which is slow because it needs to load the recipe from disk).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
