### PR TITLE
Add/remove keep behavior (Previous PR #199 - 0.2.29 rc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ env
 _build
 
 private
+# dev tools
+.idea
 .vscode
 
 # osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,93 +1,98 @@
 # CHANGELOG
 
-This is a manually generated log to track changes to the repository for each release. 
-Each section should include general headers such as **Implemented enhancements** 
+This is a manually generated log to track changes to the repository for each release.
+Each section should include general headers such as **Implemented enhancements**
 and **Merged pull requests**. Critical items to know are:
 
- - renamed commands
- - deprecated / removed commands
- - changed defaults
- - backward incompatible changes (recipe file format? image file format?)
- - migration guidance (how to convert images?)
- - changed behaviour (recipe sections work differently)
+- renamed commands
+- deprecated / removed commands
+- changed defaults
+- backward incompatible changes (recipe file format? image file format?)
+- migration guidance (how to convert images?)
+- changed behaviour (recipe sections work differently)
 
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
- - Add `ctpcoordinates` and `ctpkeepcoordinates` to handle different formats (0.3.0)
-  - Minimum Python required is 3.7, numpy 1.20
- - Remove unecessary typing - adds bugs (0.2.37)
- - Provide data as an external package (0.2.36)
- - Restore expand_sequences to get_identifiers (0.2.35)
- - Add function to clean datasets without `DicomCleaner` [#223](https://github.com/pydicom/deid/pull/223) (0.2.34)
- - add select:vr:XX field expander to select elements by VR (0.2.33)
- - rename group:XXXX field expander to select:group:XXXX
- - add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)
- - custom class example for using dicom.Dataset, not requiring on client init [#211](https://github.com/pydicom/deid/pull/211) (0.2.31)
- - adding support for deid provided functions [#207](https://github.com/pydicom/deid/issues/207) (0.2.3)
- - update CTP deid.dicom up until [this commit](https://github.com/johnperry/CTP/commit/345b05b157c046532e8791a63ababbf6d0dba59b) (0.2.29)
- - various LGTM alert fixes [#186](https://github.com/pydicom/deid/pull/186) (0.0.28)
- - bug fix for exception when attempting to jitter DA/DT which cannot be jittered (space) [#189] (https://github.com/pydicom/deid/issues/189) (0.2.27)
- - adding support to manipulate file meta [#183](https://github.com/pydicom/deid/issues/183) (0.2.26)
- - updated pydicom dependency from 1.3.0 to 2.1.1 [#171](https://github.com/pydicom/deid/issues/171) (0.2.25)
- - bug fix for multivalued fields in %values lists [#174](https://github.com/pydicom/deid/issues/174)
- - allowing other VR types for jitter [#175](https://github.com/pydicom/deid/issues/175)
- - ensuring that an add/replace of an existing value is also updated in fields [#173](https://github.com/pydicom/deid/issues/173)
- - change to correct issue with deidentifying RGB images [#165](https://github.com/pydicom/deid/issues/165) (0.2.24)
- - removing verbosity of debug logger (0.2.23)
- - changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
- - change to return results from detect when recipe does not contain filters [#155](https://github.com/pydicom/deid/issues/155)
- - fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)
- - fixes to detect and clean to better represent keep/coordinates (0.2.20)
- - modify default VR for added tags [#146](https://github.com/pydicom/deid/issues/146), bug with private tags in %fields section [#147](https://github.com/pydicom/deid/issues/147) (0.2.19)
- - adding keepcoordinates to allow for reverse specified coordinates (0.2.18)
- - bug with empty values within %values sections [#144](https://github.com/pydicom/deid/issues/144) (0.2.17)
- - ability to save 4d dicom series as animation (0.2.16)
- - bug with multiple actions on the same header field [#140](https://github.com/pydicom/deid/issues/140) (0.2.15)
- - nested sequence in replace_identifiers/strip_sequences bug [#137](https://github.com/pydicom/deid/issues/137) (0.2.14)
- - adding custom cleaner to specify region fields (0.2.13)
- - bug with replace for tested fields (0.2.12)
- - fixing func args to be kwargs (0.2.11)
- - DicomCleaner empty method does not handle list (0.2.1)
- - refactor to use iterall for all fields (0.2.0)
- - including private tags in parsing (0.1.42)
- - adding filters (contains through missing) for REMOVE (0.1.41)
- - adding support for tag groups (values, fields) (0.1.4)
- - Adding option to provide function to remove (must return boolean) (0.1.38)
- - removing matplotlib version requirement (0.1.37)
- - Matplotlib dependency >= 2.1.2 (0.1.36)
- - Adding black formatting, tests run in GitHub actions (0.1.35)
- - Adding option to recursively replace sequences (0.1.34)
- - adding pylint to clean up code (0.1.33)
- - removing dependency that isn't used (simplejson) (0.1.31)
- - updating cleaner to use pixel array (0.1.30)
- - validation function should use debug verbository, bumping license year [#92](https://github.com/pydicom/deid/issues/92) (0.1.29)
- - bumping pydicom to 1.2.0 [#91](https://github.com/pydicom/deid/issues/91) (0.1.28)
- - header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89) (0.1.27)
- - added all, allexcept, contains to field filters [#87](https://github.com/pydicom/deid/pull/87) (0.1.26)
- - fixing bug in jitter timestamp function [#85](https://github.com/pydicom/deid/pull/85) (0.1.25)
- - installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)
- - updating deid.dicom with contribution from @fimafurman [#63](https://github.com/pydicom/deid/issues/63) (0.1.22)
- - adding "func" option for recipe to pass function (0.1.21)
- - fixing client bug, redoing docs to be better organized (0.1.20)
- - Removing MediaStorageSOPInstanceUID from file_meta, issue #72 (0.1.19)
- - need to clean up temporary directory (mkdtemp), issue #68 (0.1.18)
- - fixing issue #65, save for compressed data (0.1.17)
- - matplotlib must be less than or equal to 2.1.2 for install (0.1.16)
- - fixing bug with clean coordinate flipping rectangle
- - Fixing bug with saving self.cleaned (0.1.15)
- - Allowing for datasets to be passed in functions (not necessary for files) (0.1.14)
- - index should be full path in header.py (0.1.13)
- - pydicom bumped to install latest (1.0.2) (0.1.12)
- - ensuring that ids for images are full paths (0.1.11)
- - addition of the DeidRecipe class to better interact with and combine deid recipe files.
- - the get_files function now returns a generator instead of a list.
+
+- Add `ctpcoordinates` and `ctpkeepcoordinates` to handle different formats (0.3.0)
+- Minimum Python required is 3.7, numpy 1.20
+- Remove unecessary typing - adds bugs (0.2.37)
+- Provide data as an external package (0.2.36)
+- Restore expand_sequences to get_identifiers (0.2.35)
+- Add function to clean datasets without `DicomCleaner` [#223](https://github.com/pydicom/deid/pull/223) (0.2.34)
+- add select:vr:XX field expander to select elements by VR (0.2.33)
+- rename group:XXXX field expander to select:group:XXXX
+- add group:XXXX field expander to select all elements with a specified DICOM tag group (0.2.32)
+- custom class example for using dicom.Dataset, not requiring on client init [#211](https://github.com/pydicom/deid/pull/211) (0.2.31)
+- adding support for deid provided functions [#207](https://github.com/pydicom/deid/issues/207) (0.2.3)
+- update CTP deid.dicom up until [this commit](https://github.com/johnperry/CTP/commit/345b05b157c046532e8791a63ababbf6d0dba59b) (0.2.29)
+- various LGTM alert fixes [#186](https://github.com/pydicom/deid/pull/186) (0.0.28)
+- `REPLACE/JITTER` actions have now higher priority than `REMOVE`, allowing to whitelist fields from `REMOVE ALL/Field` [#197](https://github.com/pydicom/deid/issues/197)
+- `ADD/KEEP` actions have now higher priority than `REMOVE`, allowing to whitelist fields from `REMOVE ALL/Field` [#197](https://github.com/pydicom/deid/issues/197)
+- updated pydicom dependency from 2.1.1 to 2.2.2 [#194](https://github.com/pydicom/deid/issues/194)
+- bug fix for exception when attempting to jitter DA/DT which cannot be jittered (space) [#189] (<https://github.com/pydicom/deid/issues/189>) (0.2.27)
+- adding support to manipulate file meta [#183](https://github.com/pydicom/deid/issues/183) (0.2.26)
+- updated pydicom dependency from 1.3.0 to 2.1.1 [#171](https://github.com/pydicom/deid/issues/171) (0.2.25)
+- bug fix for multivalued fields in %values lists [#174](https://github.com/pydicom/deid/issues/174)
+- allowing other VR types for jitter [#175](https://github.com/pydicom/deid/issues/175)
+- ensuring that an add/replace of an existing value is also updated in fields [#173](https://github.com/pydicom/deid/issues/173)
+- change to correct issue with deidentifying RGB images [#165](https://github.com/pydicom/deid/issues/165) (0.2.24)
+- removing verbosity of debug logger (0.2.23)
+- changing iteration technique through fields to properly add nested uids [#153](https://github.com/pydicom/deid/issues/153) (0.2.22)
+- change to return results from detect when recipe does not contain filters [#155](https://github.com/pydicom/deid/issues/155)
+- fix to correct bug in detect [#142](https://github.com/pydicom/deid/issues/142)  (0.2.21)
+- fixes to detect and clean to better represent keep/coordinates (0.2.20)
+- modify default VR for added tags [#146](https://github.com/pydicom/deid/issues/146), bug with private tags in %fields section [#147](https://github.com/pydicom/deid/issues/147) (0.2.19)
+- adding keepcoordinates to allow for reverse specified coordinates (0.2.18)
+- bug with empty values within %values sections [#144](https://github.com/pydicom/deid/issues/144) (0.2.17)
+- ability to save 4d dicom series as animation (0.2.16)
+- bug with multiple actions on the same header field [#140](https://github.com/pydicom/deid/issues/140) (0.2.15)
+- nested sequence in replace_identifiers/strip_sequences bug [#137](https://github.com/pydicom/deid/issues/137) (0.2.14)
+- adding custom cleaner to specify region fields (0.2.13)
+- bug with replace for tested fields (0.2.12)
+- fixing func args to be kwargs (0.2.11)
+- DicomCleaner empty method does not handle list (0.2.1)
+- refactor to use iterall for all fields (0.2.0)
+- including private tags in parsing (0.1.42)
+- adding filters (contains through missing) for REMOVE (0.1.41)
+- adding support for tag groups (values, fields) (0.1.4)
+- Adding option to provide function to remove (must return boolean) (0.1.38)
+- removing matplotlib version requirement (0.1.37)
+- Matplotlib dependency >= 2.1.2 (0.1.36)
+- Adding black formatting, tests run in GitHub actions (0.1.35)
+- Adding option to recursively replace sequences (0.1.34)
+- adding pylint to clean up code (0.1.33)
+- removing dependency that isn't used (simplejson) (0.1.31)
+- updating cleaner to use pixel array (0.1.30)
+- validation function should use debug verbository, bumping license year [#92](https://github.com/pydicom/deid/issues/92) (0.1.29)
+- bumping pydicom to 1.2.0 [#91](https://github.com/pydicom/deid/issues/91) (0.1.28)
+- header expansions starts with and ends with should support regular expression OR (|) [#89](https://github.com/pydicom/deid/issues/89) (0.1.27)
+- added all, allexcept, contains to field filters [#87](https://github.com/pydicom/deid/pull/87) (0.1.26)
+- fixing bug in jitter timestamp function [#85](https://github.com/pydicom/deid/pull/85) (0.1.25)
+- installation order of pydicom / matplotlib changes default python [#81](https://www.github.com/pydicom/deid/issues/81) (0.1.23)
+- updating deid.dicom with contribution from @fimafurman [#63](https://github.com/pydicom/deid/issues/63) (0.1.22)
+- adding "func" option for recipe to pass function (0.1.21)
+- fixing client bug, redoing docs to be better organized (0.1.20)
+- Removing MediaStorageSOPInstanceUID from file_meta, issue #72 (0.1.19)
+- need to clean up temporary directory (mkdtemp), issue #68 (0.1.18)
+- fixing issue #65, save for compressed data (0.1.17)
+- matplotlib must be less than or equal to 2.1.2 for install (0.1.16)
+- fixing bug with clean coordinate flipping rectangle
+- Fixing bug with saving self.cleaned (0.1.15)
+- Allowing for datasets to be passed in functions (not necessary for files) (0.1.14)
+- index should be full path in header.py (0.1.13)
+- pydicom bumped to install latest (1.0.2) (0.1.12)
+- ensuring that ids for images are full paths (0.1.11)
+- addition of the DeidRecipe class to better interact with and combine deid recipe files.
+- the get_files function now returns a generator instead of a list.
 
 ## [0.1.1](https://pypi.python.org/packages/28/26/ee80e7f1c3f65fae1c901497bb2388701158f0c96e0d633ab301abeaa478/deid-0.1.1.tar.gz#md5=39df7efb03e5d3b63308016742062a43) (0.1.1)
 
 **additions**
- - addition of this CHANGELOG and an AUTHORS and CONTRIBUTING file to properly open source the project.
+
+- addition of this CHANGELOG and an AUTHORS and CONTRIBUTING file to properly open source the project.
 **bug fix**
- - when the user specifies a deid recipe, instead of adding it to a base template we honor the choice and don't append a base.
+- when the user specifies a deid recipe, instead of adding it to a base template we honor the choice and don't append a base.
 **creation**
- - this is the initial creation of deid, including recipes for cleaning of image headers and flagging of potential phi in pixels.
+- this is the initial creation of deid, including recipes for cleaning of image headers and flagging of potential phi in pixels.

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -32,6 +32,11 @@ class DicomParser:
     file. For each, we store the element and child elements
     """
 
+    """
+    list of fields to exclude from remove because they are replaced and jittered
+    """
+    _excluded_fields = None
+
     def __init__(
         self, dicom_file, recipe=None, config=None, force=True, disable_skip=False
     ):
@@ -280,6 +285,41 @@ class DicomParser:
             skips = self.config.get("get", {}).get("skip", {})
         return skips
 
+    @property
+    def keep(self):
+        """
+        Return a list of fields to keep original, as defined by all KEEP actions in recipe
+        Those fields are not impacted by REPLACE/JITTER actions
+        """
+        keeps = []
+        if self.recipe.deid is not None:
+            keeps = [
+                action.get("field")
+                for action in self.recipe.get_actions(action="KEEP")
+                if action and action.get("field")
+            ]
+        return keeps
+
+    @property
+    def excluded_from_deletion(self):
+        """
+        Return once-evaluated list of fields that are not removed by REMOVE ALL or REMOVE SomeField,
+        as they later have to be changed by REPLACE / JITTER
+        That allows whitelisting fields from REMOVE ALL/SomeField to change them if needed (i.e. obfuscation)
+        """
+        if self._excluded_fields is None:
+            self._excluded_fields = []
+            if self.recipe.deid is not None:
+                self._excluded_fields = [
+                    action.get("field")
+                    for action in (
+                        self.recipe.get_actions(action="JITTER")
+                        + self.recipe.get_actions(action="REPLACE")
+                    )
+                    if action and action.get("field")
+                ]
+        return self._excluded_fields
+
     def get_fields(self, expand_sequences=True):
         """expand all dicom fields into a list, where each entry is
         a DicomField. If we find a sequence, we unwrap it and
@@ -290,7 +330,7 @@ class DicomParser:
                 dicom=self.dicom,
                 expand_sequences=expand_sequences,
                 seen=self.seen,
-                skip=self.skip,
+                skip=self.skip + self.keep,
             )
         return self.fields
 
@@ -347,12 +387,12 @@ class DicomParser:
 
         Parameters
         ==========
-        fields: if provided, a filtered list of fields for expand
+        field: a field for expand
+        value: field value
         action: the action from the parsed deid to take
            "field" (eg, PatientID) the header field to process
            "action" (eg, REPLACE) what to do with the field
            "value": if needed, the field from the response to replace with
-        filemeta (bool) perform on filemeta
         """
         # Validate the action
         if action not in valid_actions:
@@ -364,7 +404,7 @@ class DicomParser:
             values = self.lookup.get(re.sub("^values:", "", field), [])
             fields = self.find_by_values(values=values)
 
-        # A fields list is used vertbatim
+        # A fields list is used verbatim
         # In expand_field_expression below, the stripped_tag is being passed in to field.  At this point,
         # expanders for %fields lists have already been processed and each of the contenders is an
         # identified, unique field.  It is important to use stripped_tag at this point instead of
@@ -509,7 +549,7 @@ class DicomParser:
 
             # If a value is defined, parse it (could be filter)
             do_removal = True
-            if value != None:
+            if value is not None:
                 do_removal = parse_value(
                     item=self.lookup,
                     dicom=self.dicom,
@@ -518,7 +558,7 @@ class DicomParser:
                     funcs=self.deid_funcs,
                 )
 
-            if do_removal is True:
+            if do_removal is True and not (field.name in self.excluded_from_deletion):
                 self.delete_field(field)
 
     def remove_private(self):

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -677,6 +677,332 @@ class TestDicom(unittest.TestCase):
         with self.assertRaises(KeyError):
             parser.dicom["00331019"].value
 
+    def test_remove_all_keep_field_compounding_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertIsNotNone(parser.dicom["StudyDate"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_except_field_keep_other_field_compounding_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "except:Manufacturer"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertIsNotNone(parser.dicom["Manufacturer"])
+        self.assertIsNotNone(parser.dicom["ManufacturerModelName"])
+        self.assertIsNotNone(parser.dicom["StudyDate"])
+
+    def test_remove_all_add_field_compounding_should_add(self):
+        """
+        %header
+        REMOVE ALL
+        ADD PatientIdentityRemoved Yes
+        ADD StudyDate 19700101
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+            {"action": "ADD", "field": "StudyDate", "value": "19700101"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_blank_field_compounding_should_remove(self):
+        """
+        %header
+        REMOVE ALL
+        ADD PatientIdentityRemoved Yes
+        BLANK StudyDate
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+            {"action": "BLANK", "field": "StudyDate"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        with self.assertRaises(KeyError):
+            check3 = parser.dicom["StudyDate"].value
+
+    def test_blank_field_keep_field_compounding_should_keep(self):
+        """
+        %header
+        ADD PatientIdentityRemoved Yes
+        BLANK StudyDate
+        KEEP StudyDate
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+            {"action": "BLANK", "field": "StudyDate"},
+            {"action": "KEEP", "field": "StudyDate"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_keep_add_field_compounding_should_add(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        ADD StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "ADD", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_replace_one_should_replace(self):
+        """
+        %header
+        REMOVE ALL
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_jitter_one_should_jitter(self):
+        """
+        %header
+        REMOVE ALL
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230102", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_keep_one_replace_it_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_all_keep_one_jitter_it_should_keep(self):
+        """
+        %header
+        REMOVE ALL
+        KEEP StudyDate
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "ALL"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_field_replace_it_should_replace(self):
+        """
+        %header
+        REMOVE StudyDate
+        REPLACE StudyDate 19700101
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "StudyDate"},
+            {"action": "REPLACE", "field": "StudyDate", "value": "19700101"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("19700101", parser.dicom["StudyDate"].value)
+
+    def test_remove_field_jitter_it_should_jitter(self):
+        """
+        %header
+        REMOVE StudyDate
+        JITTER StudyDate 1
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "StudyDate"},
+            {"action": "JITTER", "field": "StudyDate", "value": "1"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230102", parser.dicom["StudyDate"].value)
+
+    def test_remove_field_keep_same_field_compounding_should_keep(self):
+        """
+        %header
+        REMOVE StudyDate
+        KEEP StudyDate
+        ADD PatientIdentityRemoved Yes
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "StudyDate"},
+            {"action": "KEEP", "field": "StudyDate"},
+            {"action": "ADD", "field": "PatientIdentityRemoved", "value": "Yes"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertEqual("Yes", parser.dicom["PatientIdentityRemoved"].value)
+        self.assertIsNotNone(parser.dicom["PixelData"])
+        self.assertEqual("20230101", parser.dicom["StudyDate"].value)
+
+    def test_remove_except_is_acting_as_substring(self):
+        """
+        %header
+        REMOVE except:Manufacturer
+        """
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": "except:Manufacturer"},
+        ]
+        recipe = create_recipe(actions)
+
+        parser = DicomParser(dicom_file, recipe=recipe)
+        parser.parse()
+
+        self.assertIsNotNone(parser.dicom["Manufacturer"])
+        self.assertIsNotNone(parser.dicom["ManufacturerModelName"])
+
     def test_strip_sequences(self):
         """
         Testing strip sequences: Checks to ensure that the strip_sequences removes all tags of type

--- a/deid/version.py
+++ b/deid/version.py
@@ -14,6 +14,6 @@ LICENSE = "LICENSE"
 INSTALL_REQUIRES = (
     ("matplotlib", {"min_version": None}),
     ("numpy", {"min_version": "1.20"}),
-    ("pydicom", {"min_version": "2.1.1"}),
+    ("pydicom", {"min_version": "2.2.2"}),
     ("python-dateutil", {"min_version": None}),
 )

--- a/docs/_docs/user-docs/recipe-headers.md
+++ b/docs/_docs/user-docs/recipe-headers.md
@@ -4,8 +4,8 @@ category: User Documentation
 order: 3
 ---
 
-As you recall from the [configuration]({{ site.baseurl }}/getting-started/dicom-config/) 
-notes page, the deid recipe allows you to configure both cleaning of pixels 
+As you recall from the [configuration]({{ site.baseurl }}/getting-started/dicom-config/)
+notes page, the deid recipe allows you to configure both cleaning of pixels
 and changing header values. This document covers the second - how to get, update,
 and replace header values.
 
@@ -19,9 +19,9 @@ Cleaning headers in dicom images typically has four parts:
  3. update these fields as you see needed
  4. [put]({{ site.baseurl }}/getting-started/dicom-put) (possibly updated) identifiers back into the data, and deidentify fully.
 
-this document will talk about the first step in this process, 
-how you can configure rules for the software. If you are interested in the command 
-line client for these commands (and not functions) you should read about 
+this document will talk about the first step in this process,
+how you can configure rules for the software. If you are interested in the command
+line client for these commands (and not functions) you should read about
 [the client]({{ site.baseurl }}/user-docs/client/).
 
 <a id="defaults">
@@ -36,24 +36,24 @@ The application does the following, by default, taking a conservative de-identif
 
 However, you might want to do either of the following:
 
- - have a specific action for some set of headers, where actions include `BLANK`, `REPLACE`, `JITTER`, `REMOVE`, and `KEEP`
- - perform some custom functions between `get`, `update`, and `put`.
+- have a specific action for some set of headers, where actions include `BLANK`, `REPLACE`, `JITTER`, `REMOVE`, `ADD` and `KEEP`
+- perform some custom functions between `get`, `update`, and `put`.
 
-We will show you a working example of the above as you continue this walkthrough. For now, let's review configuration settings. 
+We will show you a working example of the above as you continue this walkthrough. For now, let's review configuration settings.
 
 <a id="standard-anonymization">
 ### Standard Anonymization
-For a best effort anonymization, you will likely want to extract data, replace some fields, 
-and put back the replacements. In this case you need to make a config file that should be provided with your function calls. 
+For a best effort anonymization, you will likely want to extract data, replace some fields,
+and put back the replacements. In this case you need to make a config file that should be provided with your function calls.
 
 > The configuration files for deid are called "deid recipes"
- 
-The format of this file is discussed below, and can be used to specify preferences 
+
+The format of this file is discussed below, and can be used to specify preferences
 for different kinds of datasets (dicom or nifti) and things to identify (pixels and headers).
 
 <a id="rules">
 ## Rules
-You can create a specification of rules for the application to customize its behavior. 
+You can create a specification of rules for the application to customize its behavior.
 The file standard that I've been using is to call all files `deid` and use a reverse extension to indicate tag,
 so `deid.dicom` is a deid recipe for dicom, and `deid.chest-xray` might be a recipe for chest xray.
 `deid.dicom.chest-xray` could combine those two things, suggesting a recipe for dicom chest xrays.
@@ -72,16 +72,16 @@ JITTER StudyDate var:entity_timestamp
 REMOVE ReferringPhysicianName
 ```
 
-In the above example, we tell the application exactly how to deal with header fields for dicom. 
-We do that by way of sections (the lines that begin with `%` like `%header` and actions (eg, `KEEP`). 
+In the above example, we tell the application exactly how to deal with header fields for dicom.
+We do that by way of sections (the lines that begin with `%` like `%header` and actions (eg, `KEEP`).
 The fields above can include those that are specified in the [file-meta](http://dicom.nema.org/dicom/2013/output/chtml/part10/chapter_7.html) section of the dicom, which are a unique namespace.
 Each of these variables will be discussed in detail, next.
 
 <a id="format">
 ### Format
-The first thing that should appear in a recipe file is the `FORMAT` label. This is a message to the 
-application that the following commands are intended for dicom files, and the name `dicom` 
-matches exactly with the "dicom" module in the deid module. 
+The first thing that should appear in a recipe file is the `FORMAT` label. This is a message to the
+application that the following commands are intended for dicom files, and the name `dicom`
+matches exactly with the "dicom" module in the deid module.
 
 <a id="sections">
 ### Sections
@@ -91,14 +91,14 @@ Each section corresponds to a part of the data (eg, header or pixels) and then d
 #### Actions
 Although different sections can have their own actions defined, for simplicity many sections share the same set:
 
- - ADD
- - BLANK
- - JITTER
- - KEEP
- - REMOVE
- - REPLACE
+- ADD
+- BLANK
+- JITTER
+- KEEP
+- REMOVE
+- REPLACE
 
-And the command in the file will either have the format of `<ACTION> <FIELD> <VALUE>` or 
+And the command in the file will either have the format of `<ACTION> <FIELD> <VALUE>` or
 in the case of binary actions, just `<ACTION> <VALUE>`. For example, both of the following are valid:
 
 ```
@@ -120,7 +120,7 @@ by default we do not let you change a set of protected fields.
 - `BluePaletteColorLookupTableData`
 - `VOILUTSequence`
 
-These fields are found within the header, and since we load the file metadata as well, 
+These fields are found within the header, and since we load the file metadata as well,
 we also protect the following:
 
 - `FileMetaInformationGroupLength`
@@ -134,14 +134,13 @@ If you want to modify the set of skipped fields, then you can create your own
 [config.json](https://github.com/pydicom/deid/blob/master/deid/dicom/config.json) and provide
 the path as the `config` argument to either of these functions/classes.
 
-
 <a id="dynamic-values">
 #### Dynamic Values
 
 **var**
 
-In the case that your need to do something like "replace FIELD with my other variable," 
-then you want to format the value to tell the application that it should find the field 
+In the case that your need to do something like "replace FIELD with my other variable,"
+then you want to format the value to tell the application that it should find the field
 in the data structure you pass it (discussed later). That format looks like this:
 
 ```
@@ -149,10 +148,9 @@ in the data structure you pass it (discussed later). That format looks like this
 REPLACE PatientID var:suid
 ```
 
-In the above, we tell the software to replace the field `PatientID` with whatever 
-value is defined under variable `suid`. Now let's talk about how the actions are 
+In the above, we tell the software to replace the field `PatientID` with whatever
+value is defined under variable `suid`. Now let's talk about how the actions are
 relevant to different sections, first the header.
-
 
 **func**
 
@@ -185,7 +183,7 @@ that you define in a function, you can use a function with `REMOVE`:
 REMOVE ALL func:is_name
 ```
 
-The function should return a boolean (True or False) to indicate if you want 
+The function should return a boolean (True or False) to indicate if you want
 the field in question removed. For the above, all fields would be checked
 against your function to determine removal status. Here is an example
 function that grabs a patient name, and then checks fields to see
@@ -211,28 +209,29 @@ with (in the example above we grab the `PatientName`).
 <a id="header">
 #### Header
 
-We know that we are dealing with functions relevant to the header of the image 
-by way of the `%header` section. This section can have a series of commands called 
-actions that tell the software how to deal with different fields. For the header 
-section, the following actions are allowed, and each is specific to an action to 
+We know that we are dealing with functions relevant to the header of the image
+by way of the `%header` section. This section can have a series of commands called
+actions that tell the software how to deal with different fields. For the header
+section, the following actions are allowed, and each is specific to an action to
 be taken on a header field/value:
 
- - ADD: Add a new field to the dataset(s). If the value is a string, it's assumed to be the value that is desired to be added. If the value is in the form `var:OrdValue` then the application will expect to find the value to replace in a variable in the request called `OrdValue` (more on this later).
- - BLANK: If you want to blank a field instead of remove it, use this option. This is the default action.
- - KEEP: implies that the value should not be replaced, removed, or blanked.
- - REPLACE: implies that the value should be replaced by a string, or a variable in the format `var:FieldName`.
- - REMOVE: completely remove the field from the dataset.
+- ADD: Add a new field to the dataset(s). If the value is a string, it's assumed to be the value that is desired to be added. If the value is in the form `var:OrdValue` then the application will expect to find the value to replace in a variable in the request called `OrdValue` (more on this later).
+- BLANK: If you want to blank a field instead of remove it, use this option. This is the default action.
+- KEEP: implies that the value should not be replaced, jittered, removed, or blanked.
+- REPLACE: implies that the value should be replaced by a string, or a variable in the format `var:FieldName`.
+- JITTER: implies that the value should be jittered ("deviated") by a string, or a variable in the format `var:FieldName`.
+- REMOVE: completely remove the field from the dataset (if not protected by `KEEP`, changed by 'REPLACE' or 'JITTER', or is in default skip list).
 
 For the above, given that there are conflicting commands, the more conservative is given preference. For example:
 
 ```
-REMOVE > BLANK > REPLACE > JITTER/KEEP/ADD
-``` 
+KEEP > ADD > REPLACE > JITTER > REMOVE > BLANK
+```
 
-For example, if I add or keep a header, but then also specify to blank or remove it, 
-it will be blanked or removed. If I specify to blank a header and remove it, it will be removed. 
-If I specify to replace a header and blank it, it will be blanked. Most of the time, 
-you won't need to specify remove, because it is the default. If we were to come up with 
+For example, if I add or keep a header, and then also specify to blank or remove it,
+it will be kept. If I specify to blank a header and remove it, it will be removed.
+If I specify to replace a header and blank it, it will be blanked. Most of the time,
+you won't need to specify remove, because it is the default. If we were to come up with
 a pretend config file to represent the default, it would look like this:
 
 ```
@@ -248,8 +247,8 @@ KEEP Columns
 KEEP Rows
 ```
 
-The above would remove everything except for the pixel data, and a few fields 
-that are relevant to its dimensions. It would add a field to indicate the 
+The above would remove everything except for the pixel data, and a few fields
+that are relevant to its dimensions. It would add a field to indicate the
 patient's identity was removed.
 
 <a id="jitter">
@@ -265,7 +264,7 @@ JITTER PatientBirthDate -31
 <a id="field-expansion">
 ##### Field Expansion
 
-In some cases, it might be extremely tenuous to list every field ending in the same thing, 
+In some cases, it might be extremely tenuous to list every field ending in the same thing,
 to perform the same action for. For example:
 
 ```
@@ -280,11 +279,11 @@ could much better be captured as:
 JITTER endswith:Date var:jitter
 ```
 
-and this is the idea of an `expander`. And expander is an optional filter 
-applied to a header field (the middle value) to select some subset of header 
+and this is the idea of an `expander`. And expander is an optional filter
+applied to a header field (the middle value) to select some subset of header
 values. Currently, we support `startswith`, `endswith`, `contains`, `select`,
 `allexcept`, and `allfields`.
- 
+
 The following examples show what fields are selected based on each filter. For
 all examples, the test is done making the values lowercase.
 
@@ -312,9 +311,8 @@ REMOVE startswith:Patient
 **contains**
 
 The contains filter searches for a string of interest in the field. For example, if
-we ask for fields that contain "Name" will look for header field names that contain the string 
+we ask for fields that contain "Name" will look for header field names that contain the string
 "Name" in any casing.
-
 
 ```
 BLANK contains:Name
@@ -367,8 +365,8 @@ ADD ALL func:remove_identifiers
 
 **except**
 
-Akin to all fields, except provide a list of fields that you want to disclude from
-a global selector. Here are some examples to include all fields except StudyDate 
+Akin to all fields, except provide a pattern that you want to exclude from
+a global selector. Here are some examples to include all fields except StudyDate
 or StudyTime.
 
 ```
@@ -376,7 +374,15 @@ BLANK except:StudyDate|StudyTime
 BLANK except:StudyTime
 ```
 
-If you are familiar with regular expressions, you'll notice the "|" which 
+_except_ is checking field names against given pattern, so if you for example set
+
+```
+REMOVE except:Manufacturer
+```
+
+following fields will be preserved: `Manufacturer` **and** `ManufacturerModelName`
+
+If you are familiar with regular expressions, you'll notice the "|" which
 means "or" in the regular expression. You are free to write whatever regular
 expression fits your needs to disclude particular fields here.
 
@@ -461,7 +467,7 @@ are working to expose even private tags for parsing.
 <a id="example">
 ## Example
 
-The suggested approach that you should take, replacing the main entity data 
+The suggested approach that you should take, replacing the main entity data
 with some identifier that you've selected, would look something like this:
 
 ```
@@ -485,15 +491,15 @@ REPLACE PatientID var:id
 REPLACE SOPInstanceUID var:source_id
 ```
 
-And the expectation would be that you provide variables with keys `source_id` and `id` 
-appended to the response from get that is handed to the put action. 
+And the expectation would be that you provide variables with keys `source_id` and `id`
+appended to the response from get that is handed to the put action.
 
 <a id="future-additions">
 ## Future Additions
 
 <a id="format-nifti">
 ### Format nifti
-In the future when we add support for other data types, the config might look 
+In the future when we add support for other data types, the config might look
 something like this (note the added nifti section):
 
 ```
@@ -537,14 +543,14 @@ REMOVE ALL contains:(\d{7,0})
 Would parse through ALL fields, and remove those that contain a match to the regular
 expression. All supported expanders include:
 
- - contains
- - notcontains
- - equals
- - notequals 
+- contains
+- notcontains
+- equals
+- notequals
 
 Now that you know how configuration works, you have a few options.
 You can learn how to define groups of tags based on fields or values in [groups]({{ site.baseurl }}/user-docs/recipe-groups/),
-or if you want to write a text file and get going with cleaning your files, you should 
+or if you want to write a text file and get going with cleaning your files, you should
 look at some examples for generating a basic [get]({{ site.baseurl }}/getting-started/dicom-get/).
 This is the action to get a set of fields and values from your dicom files. For a full walk through
 example with a recipe, see the [recipe example]({{ site.baseurl }}/examples/recipe)


### PR DESCRIPTION
# Description

Related issues: #197, #198, #204, 

Whitelisting was not possible for replacing. Now fields being replaced or jittered are excluded from removal (either REMOVE ALL or REMOVE SomeField).

It is done using separate property and private variable to keep result (lazy eval).

Made clarification regarding KEEP list - those fields are being removed from field list to process, meaning that KEEP SomeField + REPLACE SomeField ... won't work, as kept field is being excluded from list of fields to process for other actions.

Added tests.
Bumped release candidate number and changelog (+small fix for previous change)

Minor docs update.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
