### PR TITLE
filter.py - Allow tags to be specified using a string containing a 0x-prefix hex number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Allow filter tag names to be 0x-prefix hex numbers so private tags can be referenced in recipes [#253]
 - Fix incorrect coordinate definition for GE CT [#249](https://github.com/pydicom/deid/issues/249)
 - Circular import error [#247](https://github.com/pydicom/deid/issues/247) (0.3.21)
 - Expand BLANK Action to additional VRs [#241](https://github.com/pydicom/deid/issues/241) (0.3.2)

--- a/deid/dicom/filter.py
+++ b/deid/dicom/filter.py
@@ -24,11 +24,14 @@ def apply_filter(dicom, field, filter_name, value):
     Parameters
     ==========
     dicom: the pydicom.dataset Dataset (pydicom.read_file)
-    field: the name of the field to apply the filter to
+    field: the name of the field to apply the filter to,
+      or the tag number as a string '0xGGGGEEEE'
     filer_name: the name of the filter to apply (e.g., contains)
     value: the value to set, if filter_name is valid
 
     """
+    if '0x' in field:
+        field = int(field, 0) # 0=decode hex with 0x prefix
     filter_name = filter_name.lower().strip()
 
     if filter_name == "contains":

--- a/deid/tests/resources/filter_tag_number.dicom
+++ b/deid/tests/resources/filter_tag_number.dicom
@@ -1,0 +1,9 @@
+FORMAT dicom
+
+%filter blacklist
+
+LABEL - To be tested with Cat.dcm.  Intended to NOT flag the image.
+  contains 0x00110003 Agfa
+
+%header
+ADD PatientIdentityRemoved No

--- a/deid/tests/test_filter_detect.py
+++ b/deid/tests/test_filter_detect.py
@@ -47,6 +47,17 @@ class TestFilterDetect(unittest.TestCase):
         out = client.detect(dicom_file)
         self.assertTrue(out["flagged"])
 
+    def test_filter_tag_number(self):
+        """Test the DicomCleaner.detect to ensure numeric tag numbers can be used """
+        from deid.dicom import DicomCleaner
+
+        dicom_file = get_file(self.dataset)
+        deid = os.path.join(self.deidpath, "filter_tag_number.dicom")
+
+        client = DicomCleaner(output_folder=self.tmpdir, deid=deid)
+        out = client.detect(dicom_file)
+        self.assertTrue(out["flagged"])
+
     def test_filter_single_rule_innerop_false(self):
         """Test the DicomCleaner.detect to ensure a single rule with an inner operator evaluated to false detects appropriately."""
         from deid.dicom import DicomCleaner

--- a/docs/_docs/user-docs/recipe-filters.md
+++ b/docs/_docs/user-docs/recipe-filters.md
@@ -91,7 +91,11 @@ report to the user given that the flag goes off. Each criteria then has the foll
 ```
 <criteria> <field> <value>
 ```
-where "value" is optional, depending on the filter. For example:
+where "criteria" is a test such as "contains", "notcontains",
+"equals", "notequals", "missing", "present" or "empty";
+"field" is the single-word name of a DICOM tag (as known to pydicom),
+or the number as 8-digit hex format with 0x prefix;
+and "value" is optional, depending on the filter. For example:
 
 ```
 LABEL Burned In Annotation


### PR DESCRIPTION
# Description

Allow tags to be specified using a string containing a 0x-prefix hex number

Related issues: #253 

Converts a field name which is a string in the form '0xGGGGEEEE' (GroupElement) into a number so that it can be found in the dataset dict. This allows recipe rules to specify tags numerically. One use for this is to filter on private tags.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:

Need to consider the implications of #205 (Finding relocated private elements using "PrivateCreator")