### PR TITLE
explicitly check for DataElement before reference value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Exception with missing filters for non-string VR [#256](https://github.com/pydicom/deid/issues/256) (0.3.23)
 - Allow filter tag names to be 0x-prefix hex numbers so private tags can be referenced in recipes [#253](https://github.com/pydicom/deid/issues/253) (0.3.22)
 - Fix incorrect coordinate definition for GE CT [#249](https://github.com/pydicom/deid/issues/249)
 - Circular import error [#247](https://github.com/pydicom/deid/issues/247) (0.3.21)

--- a/deid/dicom/filter.py
+++ b/deid/dicom/filter.py
@@ -4,7 +4,7 @@ __license__ = "MIT"
 
 import re
 
-from pydicom.dataset import Dataset
+from pydicom.dataset import DataElement, Dataset
 
 from deid.logger import bot
 
@@ -152,7 +152,7 @@ def empty(self, field):
         return len(content) == 0
 
     # This is the case of a data element
-    elif not isinstance(content, str):
+    elif isinstance(content, DataElement):
         content = content.value
 
     if content == "":

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2023, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.3.22"
+__version__ = "0.3.23"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: #256 

Updated filter.py empty() function to explicitly check for the tag content being an instance of a DataElement instead of assuming it's a DataElement if it isn't a string.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions
None
