### PR TITLE
fix: define max version for pydicom to avoid breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Refactor INCLUDE_REQUIRES and provide max pydicom version [#267](https://github.com/pydicom/deid/pull/267) (0.3.25)
 - Support pydicom.Dataset objects created from BytesIO [#265](https://github.com/pydicom/deid/pull/265) (0.3.24)
 - Exception with missing filters for non-string VR [#256](https://github.com/pydicom/deid/issues/256) (0.3.23)
 - Allow filter tag names to be 0x-prefix hex numbers so private tags can be referenced in recipes [#253](https://github.com/pydicom/deid/issues/253) (0.3.22)

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2023, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.3.24"
+__version__ = "0.3.25"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"

--- a/deid/version.py
+++ b/deid/version.py
@@ -12,8 +12,8 @@ DESCRIPTION = "best effort deidentify dicom with python and pydicom"
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
-    ("matplotlib", {"min_version": None}),
-    ("numpy", {"min_version": "1.20"}),
-    ("pydicom", {"min_version": "2.2.2"}),
-    ("python-dateutil", {"min_version": None}),
+    "matplotlib",
+    "numpy>=1.20",
+    "pydicom>=2.2.2,<3.0.0",
+    "python-dateutil",
 )

--- a/setup.py
+++ b/setup.py
@@ -30,31 +30,7 @@ def get_requirements(lookup=None):
     if lookup is None:
         lookup = get_lookup()
 
-    install_requires = []
-    for module in lookup["INSTALL_REQUIRES"]:
-        module_name = module[0]
-        module_meta = module[1]
-
-        # Install exact version
-        if "exact_version" in module_meta:
-            dependency = "%s==%s" % (module_name, module_meta["exact_version"])
-
-        # Install min version
-        elif "min_version" in module_meta:
-            if module_meta["min_version"] is None:
-                dependency = module_name
-            else:
-                dependency = "%s>=%s" % (module_name, module_meta["min_version"])
-
-        # Install min version
-        elif "max_version" in module_meta:
-            if module_meta["max_version"] is None:
-                dependency = module_name
-            else:
-                dependency = "%s<=%s" % (module_name, module_meta["max_version"])
-
-        install_requires.append(dependency)
-    return install_requires
+    return lookup["INSTALL_REQUIRES"]
 
 
 # Make sure everything is relative to setup.py


### PR DESCRIPTION
# Description

Related issues: #266 https://github.com/pydicom/deid/issues/266

define install requires to include upper bound for pydicom.

the preference may be for an update to adopt pydicom 3 but this may be a useful fix in the short term as that may introduce breaking changes

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project (i think)


# Open questions

Questions that require more discussion or to be addressed in future development:

you may want a similar upper bound for numpy, accidentally adopting 2+ has been an issue for some
