### PR TITLE
fix: upgrade to pydicom 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Update to use pydicom 3 [#267](https://github.com/pydicom/deid/pull/267) (1.0.0)
 - Refactor INCLUDE_REQUIRES and provide max pydicom version [#267](https://github.com/pydicom/deid/pull/267) (0.3.25)
 - Support pydicom.Dataset objects created from BytesIO [#265](https://github.com/pydicom/deid/pull/265) (0.3.24)
 - Exception with missing filters for non-string VR [#256](https://github.com/pydicom/deid/issues/256) (0.3.23)

--- a/deid/dicom/filter.py
+++ b/deid/dicom/filter.py
@@ -23,7 +23,7 @@ def apply_filter(dicom, field, filter_name, value):
 
     Parameters
     ==========
-    dicom: the pydicom.dataset Dataset (pydicom.read_file)
+    dicom: the pydicom.dataset Dataset (pydicom.dcmread)
     field: the name of the field to apply the filter to,
       or the tag number as a string '0xGGGGEEEE'
     filer_name: the name of the filter to apply (e.g., contains)

--- a/deid/dicom/header.py
+++ b/deid/dicom/header.py
@@ -5,7 +5,7 @@ __license__ = "MIT"
 
 import os
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.dicom.parser import DicomParser
 from deid.dicom.utils import save_dicom
@@ -68,7 +68,7 @@ def remove_private_identifiers(
         dicom_files = [dicom_files]
 
     for dicom_file in dicom_files:
-        dicom = read_file(dicom_file, force=force)
+        dicom = dcmread(dicom_file, force=force)
         dicom.remove_private_tags()
         dicom_name = os.path.basename(dicom_file)
         bot.debug("Removed private identifiers for %s" % dicom_name)

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -7,7 +7,7 @@ import re
 from copy import deepcopy
 from io import BytesIO
 
-from pydicom import read_file
+from pydicom import dcmread
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag
@@ -99,7 +99,7 @@ class DicomParser:
             # If we must read the file, the path must exist
             if not os.path.exists(dicom_file):
                 bot.exit("%s does not exist." % dicom_file)
-            self.dicom = read_file(dicom_file, force=force)
+            self.dicom = dcmread(dicom_file, force=force)
 
         # Set class variables that might be helpful later
         df = self.dicom.get("filename")

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -13,7 +13,7 @@ from typing import Optional
 import matplotlib
 import numpy
 from numpy.typing import NDArray
-from pydicom import read_file
+from pydicom import dcmread
 from pydicom.pixel_data_handlers.util import get_expected_length
 
 from deid.config import DeidRecipe
@@ -245,7 +245,7 @@ class DicomCleaner:
         # Having clean also means has dicom image
         if hasattr(self, image_type):
             dicom_name = self._get_clean_name(output_folder)
-            dicom = read_file(self.dicom_file, force=True)
+            dicom = dcmread(self.dicom_file, force=True)
             # If going from compressed, change TransferSyntax
             if dicom.file_meta.TransferSyntaxUID.is_compressed is True:
                 dicom.decompress()

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -5,7 +5,7 @@ __license__ = "MIT"
 
 from typing import List, Optional, Union
 
-from pydicom import FileDataset, read_file
+from pydicom import FileDataset, dcmread
 from pydicom.sequence import Sequence
 
 from deid.config import DeidRecipe
@@ -114,7 +114,7 @@ def _has_burned_pixels_single(dicom_file, force: bool, deid):
     if isinstance(dicom_file, FileDataset):
         dicom = dicom_file
     else:
-        dicom = read_file(dicom_file, force=force)
+        dicom = dcmread(dicom_file, force=force)
 
     # Return list with lookup as dicom_file
     results = []

--- a/deid/dicom/tags.py
+++ b/deid/dicom/tags.py
@@ -123,7 +123,7 @@ def update_tag(dicom, field, value):
 
     Parameters
     ==========
-    dicom: the pydicom.dataset Dataset (pydicom.read_file)
+    dicom: the pydicom.dataset Dataset (pydicom.dcmread)
     field: the name of the field to update
     value: the value to set, if name is a valid tag
 
@@ -157,7 +157,7 @@ def get_private(dicom):
 
     Parameters
     ==========
-    dicom: the pydicom.dataset Dataset (pydicom.read_file)
+    dicom: the pydicom.dataset Dataset (pydicom.dcmread)
     """
     datasets = [dicom]
     private_tags = []
@@ -188,7 +188,7 @@ def has_private(dicom):
 
     Parameters
     ==========
-    dicom: the pydicom.dataset Dataset (pydicom.read_file)
+    dicom: the pydicom.dataset Dataset (pydicom.dcmread)
 
     """
     private_tags = len(get_private(dicom))

--- a/deid/dicom/utils.py
+++ b/deid/dicom/utils.py
@@ -110,4 +110,4 @@ def load_dicom(dcm_file):
     if isinstance(dcm_file, FileDataset):
         return dcm_file
     else:
-        return pydicom.read_file(dcm_file, force=True)
+        return pydicom.dcmread(dcm_file, force=True)

--- a/deid/dicom/validate.py
+++ b/deid/dicom/validate.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2023, Vanessa Sochat"
 __license__ = "MIT"
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.logger import bot
 
@@ -28,7 +28,7 @@ def validate_dicoms(dcm_files, force=False):
     for dcm_file in dcm_files:
         try:
             with open(dcm_file, "rb") as filey:
-                read_file(filey, force=force)
+                dcmread(filey, force=force)
             valids.append(dcm_file)
         except Exception:
             bot.warning("Cannot read input file {0!s}, skipping.".format(dcm_file))

--- a/deid/tests/Xtest_dicom_header.py
+++ b/deid/tests/Xtest_dicom_header.py
@@ -47,7 +47,7 @@ class TestDicomHeader(unittest.TestCase):
 
     def test_replace_identifiers(self):
         print("Testing deid.dicom replace_identifiers")
-        from pydicom import read_file
+        from pydicom import dcmread
 
         from deid.dicom import get_identifiers, replace_identifiers
 
@@ -55,7 +55,7 @@ class TestDicomHeader(unittest.TestCase):
         ids = get_identifiers(dicom_files)
 
         # Before blanking, 28 fields don't have blanks
-        notblanked = read_file(dicom_files[0])
+        notblanked = dcmread(dicom_files[0])
         notblanked_fields = [
             x for x in notblanked.dir() if notblanked.get(x) != ""
         ]  # 28
@@ -64,21 +64,21 @@ class TestDicomHeader(unittest.TestCase):
         updated_files = replace_identifiers(dicom_files, ids, output_folder=self.tmpdir)
 
         # After replacing only 9 don't have blanks
-        blanked = read_file(updated_files[0])
+        blanked = dcmread(updated_files[0])
         blanked_fields = [x for x in blanked.dir() if blanked.get(x) != ""]
         self.assertTrue(len(blanked_fields) == 9)
 
 
 def get_dicom(dataset, return_dir=False):
     """helper function to load a dicom"""
-    from pydicom import read_file
+    from pydicom import dcmread
 
     from deid.dicom import get_files
 
     dicom_files = get_files(dataset)
     if return_dir:
         return list(dicom_files)
-    return read_file(next(dicom_files))
+    return dcmread(next(dicom_files))
 
 
 if __name__ == "__main__":

--- a/deid/tests/common.py
+++ b/deid/tests/common.py
@@ -30,12 +30,12 @@ def get_dicom(dataset):
     """
     helper function to load a dicom
     """
-    from pydicom import read_file
+    from pydicom import dcmread
 
     from deid.dicom import get_files
 
     dicom_files = get_files(dataset)
-    return read_file(next(dicom_files))
+    return dcmread(next(dicom_files))
 
 
 def get_same_file(dataset):

--- a/deid/tests/test_action_interaction.py
+++ b/deid/tests/test_action_interaction.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import replace_identifiers
@@ -54,7 +54,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         with self.assertRaises(KeyError):
             inputfile[field].value
 
@@ -66,7 +66,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(value2, outputfile[field].value)
 
@@ -92,7 +92,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(1, currentValue)
@@ -106,7 +106,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(None, outputfile[field].value)
 
@@ -135,7 +135,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -149,7 +149,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -177,7 +177,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -191,7 +191,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -220,7 +220,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -234,7 +234,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -260,7 +260,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -273,7 +273,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value
@@ -302,7 +302,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -317,7 +317,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -344,7 +344,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -359,7 +359,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -387,7 +387,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -402,7 +402,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -426,7 +426,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -442,7 +442,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -470,7 +470,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -485,7 +485,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -509,7 +509,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -523,7 +523,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value
@@ -553,7 +553,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(valueexpected, currentValue)
@@ -567,7 +567,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -595,7 +595,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -609,7 +609,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -638,7 +638,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(valueexpected, currentValue)
@@ -652,7 +652,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -678,7 +678,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -693,7 +693,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -722,7 +722,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(valueexpected, currentValue)
@@ -736,7 +736,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -763,7 +763,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertEqual("20230101", currentValue)
@@ -776,7 +776,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -804,7 +804,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -819,7 +819,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -843,7 +843,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -858,7 +858,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -884,7 +884,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -899,7 +899,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -924,7 +924,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -940,7 +940,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -966,7 +966,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -981,7 +981,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1005,7 +1005,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -1020,7 +1020,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1049,7 +1049,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertNotEqual(valueexpected, currentValue)
 
@@ -1061,7 +1061,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1087,7 +1087,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -1102,7 +1102,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("", outputfile[field].value)
 
@@ -1131,7 +1131,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -1145,7 +1145,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1171,7 +1171,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -1185,7 +1185,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1214,7 +1214,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -1228,7 +1228,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1254,7 +1254,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(value1, currentValue)
@@ -1267,7 +1267,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(value1, outputfile[field].value)
 
@@ -1295,7 +1295,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -1310,7 +1310,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1334,7 +1334,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -1348,7 +1348,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value
@@ -1375,7 +1375,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -1389,7 +1389,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("20230102", outputfile[field].value)
 
@@ -1413,7 +1413,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         valueexpected = currentValue
 
@@ -1429,7 +1429,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1456,7 +1456,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -1470,7 +1470,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
@@ -1495,7 +1495,7 @@ class TestRuleInteractions(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
 
         self.assertNotEqual(None, currentValue)
@@ -1509,7 +1509,7 @@ class TestRuleInteractions(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value

--- a/deid/tests/test_blank_action.py
+++ b/deid/tests/test_blank_action.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import replace_identifiers
@@ -40,7 +40,7 @@ class TestBlankAction(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[Field].value
         currentVR = inputfile[Field].VR
 
@@ -56,7 +56,7 @@ class TestBlankAction(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(Expected, outputfile[Field].value)
 

--- a/deid/tests/test_clean.py
+++ b/deid/tests/test_clean.py
@@ -12,7 +12,7 @@ import unittest
 from copy import deepcopy
 
 import pydicom
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.config import DeidRecipe
 from deid.data import get_dataset
@@ -49,10 +49,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -63,7 +63,7 @@ class TestClean(unittest.TestCase):
 
     def test_pixel_cleaner_remove_coordinates_dicom_file(self):
         """Test the pixel cleaner to ensure it appropriately clears specified pixels."""
-        dicom_file_data = pydicom.read_file(get_file(self.dataset))
+        dicom_file_data = pydicom.dcmread(get_file(self.dataset))
         inputpixels = deepcopy(dicom_file_data.pixel_array)
 
         deid_path = os.path.join(self.deidpath, "remove_coordinates.dicom")
@@ -95,10 +95,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -121,10 +121,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertTrue(compare.all())
@@ -143,10 +143,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -168,10 +168,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -195,10 +195,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -222,10 +222,10 @@ class TestClean(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())

--- a/deid/tests/test_clean_pixel_dimensions.py
+++ b/deid/tests/test_clean_pixel_dimensions.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.utils import get_installdir
@@ -45,10 +45,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -74,10 +74,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -103,10 +103,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -132,10 +132,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -161,10 +161,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -190,10 +190,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -219,10 +219,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())
@@ -248,10 +248,10 @@ class TestCleanPizelDimensions(unittest.TestCase):
         client.clean()
         cleanedfile = client.save_dicom()
 
-        outputfile = read_file(cleanedfile)
+        outputfile = dcmread(cleanedfile)
         outputpixels = outputfile.pixel_array
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         inputpixels = inputfile.pixel_array
         compare = inputpixels == outputpixels
         self.assertFalse(compare.all())

--- a/deid/tests/test_replace_action.py
+++ b/deid/tests/test_replace_action.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import replace_identifiers
@@ -43,7 +43,7 @@ class TestReplaceAction(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[Field].value
         currentVR = inputfile[Field].VR
 
@@ -58,7 +58,7 @@ class TestReplaceAction(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(expected, outputfile[Field].value)
 

--- a/deid/tests/test_replace_identifiers.py
+++ b/deid/tests/test_replace_identifiers.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 from collections import OrderedDict
 
-from pydicom import read_file
+from pydicom import dcmread
 from pydicom.sequence import Sequence
 
 from deid.data import get_dataset
@@ -72,7 +72,7 @@ class TestDicom(unittest.TestCase):
             strip_sequences=False,
             output_folder=self.tmpdir,
         )
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
 
         self.assertEqual(1, len(result))
         self.assertEqual("SIMPSON", outputfile["11112221"].value)
@@ -118,7 +118,7 @@ class TestDicom(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         field1 = inputfile[newfield1].value
         field2 = inputfile[newfield2].value
 
@@ -155,7 +155,7 @@ class TestDicom(unittest.TestCase):
         ]
         recipe = create_recipe(actions)
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[newfield1].value
 
         self.assertNotEqual(newvalue1, currentValue)
@@ -168,7 +168,7 @@ class TestDicom(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(newvalue1, outputfile[newfield1].value)
 
@@ -280,7 +280,7 @@ class TestDicom(unittest.TestCase):
             strip_sequences=False,
             output_folder=self.tmpdir,
         )
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("SIMPSON", outputfile["11112221"].value)
         self.assertEqual("SIMPSON", outputfile["PatientIdentityRemoved"].value)
@@ -589,7 +589,7 @@ class TestDicom(unittest.TestCase):
         recipe = create_recipe(actions)
 
         # Ensure tag is present before removal
-        dicom = read_file(dicom_file)
+        dicom = dcmread(dicom_file)
         assert "0008103e" in dicom
 
         result = replace_identifiers(

--- a/deid/tests/test_sequence_blank.py
+++ b/deid/tests/test_sequence_blank.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import get_files, replace_identifiers
@@ -37,7 +37,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -49,7 +49,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("", outputfile[field].value)
 
@@ -59,7 +59,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -71,7 +71,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("", outputfile[field].value)
 
@@ -81,7 +81,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070001"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -99,7 +99,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070001"]
@@ -114,7 +114,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070002"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -130,7 +130,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070002"]
@@ -145,7 +145,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         level1parent = inputfile["00070003"]
         self.assertEqual(level1parent.VR, "SQ")
 
@@ -166,7 +166,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070003"]
@@ -187,7 +187,7 @@ class TestSequenceBlank(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "BLANK", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -206,7 +206,7 @@ class TestSequenceBlank(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["RequestAttributesSequence"]

--- a/deid/tests/test_sequence_jitter.py
+++ b/deid/tests/test_sequence_jitter.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import get_files, replace_identifiers
@@ -37,7 +37,7 @@ class TestSequenceJitter(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "JITTER", "field": field, "value": "1"}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -49,7 +49,7 @@ class TestSequenceJitter(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("20230102", outputfile[field].value)
 
@@ -59,7 +59,7 @@ class TestSequenceJitter(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "JITTER", "field": field, "value": "1"}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -71,7 +71,7 @@ class TestSequenceJitter(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("20260318", outputfile[field].value)
 
@@ -81,7 +81,7 @@ class TestSequenceJitter(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "JITTER", "field": field, "value": "1"}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070011"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -99,7 +99,7 @@ class TestSequenceJitter(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070011"]
@@ -114,7 +114,7 @@ class TestSequenceJitter(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "JITTER", "field": field, "value": "1"}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070012"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -130,7 +130,7 @@ class TestSequenceJitter(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070012"]
@@ -145,7 +145,7 @@ class TestSequenceJitter(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "JITTER", "field": field, "value": "1"}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         level1parent = inputfile["00070013"]
         self.assertEqual(level1parent.VR, "SQ")
 
@@ -166,7 +166,7 @@ class TestSequenceJitter(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070013"]

--- a/deid/tests/test_sequence_remove.py
+++ b/deid/tests/test_sequence_remove.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import get_files, replace_identifiers
@@ -37,7 +37,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -49,7 +49,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value
@@ -60,7 +60,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -72,7 +72,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         with self.assertRaises(KeyError):
             _ = outputfile[field].value
@@ -83,7 +83,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070001"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -101,7 +101,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070001"]
@@ -117,7 +117,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070002"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -133,7 +133,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070002"]
@@ -149,7 +149,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         level1parent = inputfile["00070003"]
         self.assertEqual(level1parent.VR, "SQ")
 
@@ -170,7 +170,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070003"]
@@ -192,7 +192,7 @@ class TestSequenceRemove(unittest.TestCase):
         dicom_file = next(get_files(self.dataset, pattern="ctbrain2.dcm"))
         recipe = create_recipe([{"action": "REMOVE", "field": field}])
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -211,7 +211,7 @@ class TestSequenceRemove(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["RequestAttributesSequence"]

--- a/deid/tests/test_sequence_replace.py
+++ b/deid/tests/test_sequence_replace.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from pydicom import read_file
+from pydicom import dcmread
 
 from deid.data import get_dataset
 from deid.dicom import get_files, replace_identifiers
@@ -39,7 +39,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -51,7 +51,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("ReplacementValue", outputfile[field].value)
 
@@ -63,7 +63,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -75,7 +75,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual("ReplacementValue", outputfile[field].value)
 
@@ -87,7 +87,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070001"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -105,7 +105,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070001"]
@@ -122,7 +122,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentparent = inputfile["00070002"]
         self.assertEqual(currentparent.VR, "SQ")
 
@@ -138,7 +138,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070002"]
@@ -155,7 +155,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         level1parent = inputfile["00070003"]
         self.assertEqual(level1parent.VR, "SQ")
 
@@ -176,7 +176,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["00070003"]
@@ -199,7 +199,7 @@ class TestSequenceReplace(unittest.TestCase):
             [{"action": "REPLACE", "field": field, "value": "ReplacementValue"}]
         )
 
-        inputfile = read_file(dicom_file)
+        inputfile = dcmread(dicom_file)
         currentValue = inputfile[field].value
         self.assertIsNotNone(currentValue)
 
@@ -218,7 +218,7 @@ class TestSequenceReplace(unittest.TestCase):
             strip_sequences=False,
         )
 
-        outputfile = read_file(result[0])
+        outputfile = dcmread(result[0])
         self.assertEqual(1, len(result))
 
         outputparent = outputfile["RequestAttributesSequence"]

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,8 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2023, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.3.25"
+
+__version__ = "1.0.0"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"
@@ -12,8 +13,8 @@ DESCRIPTION = "best effort deidentify dicom with python and pydicom"
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
-    "matplotlib",
-    "numpy>=1.20",
-    "pydicom>=2.2.2,<3.0.0",
-    "python-dateutil",
+    "matplotlib<4.0",
+    "numpy>=1.20,<2.0",
+    "pydicom>=3.0.1,<4.0.0",
+    "python-dateutil<3.0",
 )

--- a/docs/_docs/examples/client.md
+++ b/docs/_docs/examples/client.md
@@ -213,7 +213,7 @@ Is this accurate?
 
 ```python
 for dicom_file in dicom_files:
-    dicom = read_file(dicom_file)
+    dicom = dcmread(dicom_file)
     print("%s:%s - %s" %(os.path.basename(dicom_file),
                          dicom.OperatorsName,
                          dicom.PatientSex))

--- a/docs/_docs/examples/header-expanders.md
+++ b/docs/_docs/examples/header-expanders.md
@@ -98,8 +98,8 @@ dicom_files = list(get_files(base))
 For the purpose of exploration, let's load one file.
 
 ```python
-from pydicom import read_file
-dicom = read_file(dicom_files[0])
+from pydicom import dcmread
+dicom = dcmread(dicom_files[0])
 ```
 
 Let's play with our expanders! Remember the examples above that we wrote into

--- a/docs/_docs/examples/recipe.md
+++ b/docs/_docs/examples/recipe.md
@@ -317,8 +317,8 @@ cleaned_files = replace_identifiers(dicom_files=dicom_files,
 To check your work, you can load in a cleaned file to see what was done
 
 ```python
-from pydicom import read_file
-test_file = read_file(cleaned_files[0])
+from pydicom import dcmread
+test_file = dcmread(cleaned_files[0])
 
 # test_file
 # (0008, 0018) SOP Instance UID                    UI: cookiemonster-image-1

--- a/docs/_docs/getting-started/dicom-pixels.md
+++ b/docs/_docs/getting-started/dicom-pixels.md
@@ -371,7 +371,7 @@ import matplotlib.pyplot as plt
 
 from deid.dicom.pixels import clean_pixel_data, has_burned_pixels
 
-dicom_file_data = pydicom.read_file(DICOM_FILE)
+dicom_file_data = pydicom.dcmread(DICOM_FILE)
 
 burned_pixels_results = has_burned_pixels(dicom_file_data)
 cleaned_pixels = clean_pixel_data(

--- a/docs/_docs/getting-started/dicom-put.md
+++ b/docs/_docs/getting-started/dicom-put.md
@@ -433,8 +433,8 @@ and now the functions we can use. We will look at one dicom_file
 ```python
 from deid.dicom.tags import has_private, get_private
 
-from pydicom import read_file
-dicom = read_file(dicom_files[0])
+from pydicom import dcmread
+dicom = dcmread(dicom_files[0])
 ```
 
 Does it have private tags?

--- a/examples/dicom/dicom-extract/create-dicom-csv.py
+++ b/examples/dicom/dicom-extract/create-dicom-csv.py
@@ -49,7 +49,7 @@ def get_tags_in_files(dicom_path, tag_file_path):
     tags_in_files = {}
     dicom_file_paths = file_paths(filtered_walk(dicom_path, included_files=["*.dcm"]))
     for dicom_file_path in dicom_file_paths:
-        dicom_file = pydicom.read_file(dicom_file_path)
+        dicom_file = pydicom.dcmread(dicom_file_path)
         for item in dicom_file:
             if item.keyword not in tags_in_files:
                 group = "0x%04x" % item.tag.group
@@ -107,7 +107,7 @@ def directory_to_csv(dicom_path, csv_file_path, tags_in_files, tags_to_exclude):
 
         # write the rows
         for dicom_file_path in dicom_file_paths:
-            dicom_file = pydicom.read_file(dicom_file_path)
+            dicom_file = pydicom.dcmread(dicom_file_path)
 
             row_vals = []
             for keyword in tags_in_files:

--- a/examples/dicom/recipe/deid-dicom-example.py
+++ b/examples/dicom/recipe/deid-dicom-example.py
@@ -3,7 +3,7 @@
 import os
 
 # We can load in a cleaned file to see what was done
-from pydicom import read_file
+from pydicom import dcmread
 
 # Create a DeidRecipe
 from deid.config import DeidRecipe
@@ -196,7 +196,7 @@ cleaned_files = replace_identifiers(
 )
 
 
-test_file = read_file(cleaned_files[0])
+test_file = dcmread(cleaned_files[0])
 
 
 # test_file


### PR DESCRIPTION
# Description

Related issues: #266 https://github.com/pydicom/deid/issues/266

Please include a summary of the change(s) and if relevant, any related issues above.
update read_file to dcmread as per suggestion from pydicom 3 release notes https://github.com/pydicom/pydicom/releases/tag/v3.0.0

I couldn't tell if the other changes would cause external breaking changes.

I've run no testing

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development:
The approach as here https://github.com/pydicom/deid/pull/267/files may be worthwhile as well to avoid a similar case in the future
