### PR TITLE
Fix incorrect assignment of deeply-nested tags to top-level tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Fix incorrect assignment of deeply-nested tags to top-level tags [#277](https://github.com/pydicom/deid/pull/277) (0.4.2)
 - `deid` client saves cleaned dicoms when requested [#276](https://github.com/pydicom/deid/pull/276) (0.4.1)
 - Update to use pydicom 3 [#267](https://github.com/pydicom/deid/pull/267) (0.4.0)
 - Refactor INCLUDE_REQUIRES and provide max pydicom version [#267](https://github.com/pydicom/deid/pull/267) (0.3.25)

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -26,6 +26,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 parentheses_hex_tag_format = re.compile(r"\(([0-9A-Fa-f]{4}),([0-9A-Fa-f]{4})\)")
 bare_hex_tag_format = re.compile(r"[0-9A-Fa-f]{8}")
 
+
 class DicomParser:
     """
     Parse a dicom, performing one or more actions on fields.

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -495,7 +495,7 @@ class DicomParser:
                 self.dicom.file_meta.add(element)
             else:
                 dataset_cursor = self.dicom
-                # Navigate down the nested tag heirarchy by splitting the path
+                # Navigate down the nested tag hierarchy by splitting the path
                 # on the "__" delimiter. We split the last tag in the path out
                 # in order to use it for directly assigning the element to a
                 # nested field in the `self.dicom` dataset.

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -23,7 +23,8 @@ from deid.logger import bot
 from deid.utils import parse_value, read_json
 
 here = os.path.dirname(os.path.abspath(__file__))
-
+parentheses_hex_tag_format = re.compile(r"\(([0-9A-Fa-f]{4}),([0-9A-Fa-f]{4})\)")
+bare_hex_tag_format = re.compile(r"[0-9A-Fa-f]{8}")
 
 class DicomParser:
     """
@@ -461,13 +462,11 @@ class DicomParser:
             4. A tag name (e.g., "PatientID"), rather than a number.
             """
             if tag_string.startswith("("):
-                pattern = re.compile(r"\(([0-9A-Fa-f]{4}),([0-9A-Fa-f]{4})\)")
-                result = pattern.match(tag_string)
+                result = parentheses_hex_tag_format.match(tag_string)
                 return int(f"0x{result.group(1)}{result.group(2)}", base=16)
             else:
                 try:
-                    unannotated_hex_tag = re.compile(r"[0-9A-Fa-f]{8}")
-                    if unannotated_hex_tag.match(tag_string):
+                    if bare_hex_tag_format.match(tag_string):
                         return int(f"0x{tag_string}", base=16)
                     else:
                         return int(tag_string)

--- a/deid/tests/test_nested_dicom_fields.py
+++ b/deid/tests/test_nested_dicom_fields.py
@@ -1,0 +1,104 @@
+import contextlib
+import os
+import tempfile
+import unittest
+
+from pydicom import dcmread
+from pydicom.dataset import Dataset
+from pydicom.sequence import Sequence
+from pydicom.uid import generate_uid
+
+from deid.config import DeidRecipe
+from deid.dicom.header import get_identifiers, replace_identifiers
+
+
+@contextlib.contextmanager
+def temporary_recipe(recipe_text: str):
+    """
+    Create a temporary recipe file for testing.
+    """
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as recipe_file:
+        recipe_file.write(recipe_text.encode())
+        recipe_file.flush()
+        recipe = DeidRecipe(deid=recipe_file.name, base=False)
+        yield recipe
+
+
+def hashuid(item, value, field, dicom, element_name=None):
+    """
+    Generate a new UID based on the previous UID
+    """
+    if hasattr(field, "element"):
+        hash_src = str(field.element.value)
+    else:
+        hash_src = field
+    new_uid = generate_uid(entropy_srcs=[hash_src])
+    return new_uid
+
+
+class TestNestedDicomFields(unittest.TestCase):
+    def setUp(self):
+        print("\n######################START######################")
+
+    def tearDown(self):
+        print("\n######################END########################")
+
+    def test_nested_dicom_fields(self):
+        """
+        Tests that header deidentification does not overwrite existing top-level tags
+        when iterating over deeply nested tags.
+        """
+        # Create a mock DICOM dataset with a top-level and nested SeriesInstanceUID
+        original_dicom = Dataset()
+        original_dicom.SeriesInstanceUID = generate_uid()
+
+        referenced_series = Dataset()
+        referenced_series.SeriesInstanceUID = generate_uid()
+
+        original_dicom.ReferencedSeriesSequence = Sequence([referenced_series])
+
+        # Enforce precondition that the two SeriesInstanceUID attributes are different
+        self.assertNotEqual(
+            original_dicom.ReferencedSeriesSequence[0].SeriesInstanceUID,
+            original_dicom.SeriesInstanceUID,
+        )
+
+        recipe_text = """
+        FORMAT dicom
+        %header
+        REPLACE SeriesInstanceUID func:hashuid
+        """
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            temporary_recipe(recipe_text) as recipe,
+        ):
+            temp_file_name = os.path.join(temp_dir, "input.dcm")
+            original_dicom.save_as(temp_file_name, implicit_vr=True, little_endian=True)
+            dicom_paths = [temp_file_name]
+
+            # Add hash function to deid context
+            ids = get_identifiers(dicom_paths)
+            for dicom_id in ids:
+                ids[dicom_id]["hashuid"] = hashuid
+
+            os.makedirs(os.path.join(temp_dir, "out"))
+            output_paths = replace_identifiers(
+                dicom_paths,
+                ids=ids,
+                deid=recipe,
+                save=True,
+                overwrite=True,
+                output_folder=os.path.join(temp_dir, "out"),
+            )
+
+            output_dataset = dcmread(output_paths[0], force=True)
+            # Assert that the SeriesInstanceUID has been replaced
+            self.assertNotEqual(
+                output_dataset.SeriesInstanceUID, original_dicom.SeriesInstanceUID
+            )
+            # Assert that the two unique UIDs were deidentified to different values
+            self.assertNotEqual(
+                output_dataset.ReferencedSeriesSequence[0].SeriesInstanceUID,
+                output_dataset.SeriesInstanceUID,
+            )

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2025, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: I haven't opened an issue for this yet, nor did I see a related issue already open.

Hello pydicom team! Thanks for your excellent work on this library. I ran across an issue in production for which I wanted to push an upstream fix.

During header deidentification, deeply nested tag values (i.e. `ReferencedSeriesSequence > 0 > SeriesInstanceUID`) were being processed and saved back to the top-level tag (i.e, just the top-level `SeriesInstanceUID`). This was causing some very confusing and surprising behavior with UIDs not being converted to the expected values.

I added a minimal reproducible test case (1f9cb7e1265dab2dec8e4f42a17a06b55b43d0a9) which fails pre-patch. Once you apply commit 8b646e53c73749878e070d85a3e072e92ca23a46, the test passes.

Please let me know if you have any questions or concerns about the patch! Thanks!

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

None
