### PR TITLE
FIX: _has_burned_pixels_single - Bug in group evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Fix logic in evaluating flags for groups containing OR (`||`) [#278](https://github.com/pydicom/deid/pull/279) (0.4.3)
 - Fix incorrect assignment of deeply-nested tags to top-level tags [#277](https://github.com/pydicom/deid/pull/277) (0.4.2)
 - `deid` client saves cleaned dicoms when requested [#276](https://github.com/pydicom/deid/pull/276) (0.4.1)
 - Update to use pydicom 3 [#267](https://github.com/pydicom/deid/pull/267) (0.4.0)

--- a/deid/dicom/pixels/detect.py
+++ b/deid/dicom/pixels/detect.py
@@ -132,13 +132,14 @@ def _has_burned_pixels_single(dicom_file, force: bool, deid):
 
             # If there aren't any filters but we have coordinates, assume True
             if not item.get("filters") and item.get("coordinates"):
-                group_flags = [True]
+                this_item_flags = [True]
                 group_descriptions = [item.get("name", "")]
 
             else:
-                group_flags = []  # evaluation for a single line
+                this_item_flags = []  # evaluation for a single line
                 group_descriptions = []
                 for group in item["filters"]:
+                    this_group_flags = []
                     # You cannot pop from the list
                     for a in range(len(group["action"])):
                         action = group["action"][a]
@@ -154,18 +155,21 @@ def _has_burned_pixels_single(dicom_file, force: bool, deid):
                             filter_name=action,
                             value=value or None,
                         )
-                        group_flags.append(flag)
+                        this_group_flags.append(flag)
                         description = "%s %s %s" % (field, action, value)
 
                         if len(group["InnerOperators"]) > a:
                             inner_operator = group["InnerOperators"][a]
-                            group_flags.append(inner_operator)
+                            this_group_flags.append(inner_operator)
                             description = "%s %s" % (description, inner_operator)
 
                         group_descriptions.append(description)
 
+                    overall_group_flag = evaluate_group(this_group_flags)
+                    this_item_flags.append(overall_group_flag)
+
             # At the end of a group, evaluate the inner group
-            flag = evaluate_group(group_flags)
+            flag = evaluate_group(this_item_flags)
 
             # "Operator" is relevant for the outcome of the list of actions
             operator = ""

--- a/deid/tests/resources/remove_coordinates_groups.dicom
+++ b/deid/tests/resources/remove_coordinates_groups.dicom
@@ -1,0 +1,18 @@
+FORMAT dicom
+
+%filter graylist
+
+LABEL Groups With OR
+  contains Manufacturer foo
+  + contains ManufacturerModelName bar || contains SeriesDescription flag me
+  coordinates 0,0,1024,1024
+
+LABEL Value With OR
+  contains Manufacturer foo|bar|baz
+  + contains SeriesDescription bam
+  coordinates 0,0,10,10
+
+LABEL Value With AND
+  contains Manufacturer foo
+  + contains ImageType DERIVED+SECONDARY
+  coordinates 0,0,20,10

--- a/deid/tests/test_dicom_pixels.py
+++ b/deid/tests/test_dicom_pixels.py
@@ -1,0 +1,350 @@
+# test_dicom_pixels_detect.py
+
+import os
+import unittest
+
+from deid.dicom.pixels.detect import DeidRecipe, _has_burned_pixels_single
+from deid.utils import get_installdir
+
+# Path to test data (adjust based on your setup)
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+
+
+def create_dummy_dicom(
+    sop_class_uid=None,
+    manufacturer="foo",
+    series_description="Test Series",
+    image_type=None,
+):
+    """Create a dummy DICOM dataset for testing."""
+    import tempfile
+
+    from pydicom.dataset import Dataset, FileDataset
+
+    filename = tempfile.NamedTemporaryFile(suffix=".dcm", delete=False).name
+    file_meta = Dataset()
+    ds = FileDataset(filename, {}, file_meta=file_meta, preamble=b"\0" * 128)
+
+    ds.PatientName = "Test^BurnedPixels"
+    ds.Rows = 64
+    ds.Columns = 64
+    ds.BitsAllocated = 8
+    ds.BitsStored = 8
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.PixelRepresentation = 0
+
+    if sop_class_uid:
+        ds.SOPClassUID = sop_class_uid
+    if manufacturer:
+        ds.Manufacturer = manufacturer
+    if series_description:
+        ds.SeriesDescription = series_description
+    if image_type and isinstance(image_type, list):
+        ds.ImageType = image_type
+
+    ds.save_as(filename)
+    return filename
+
+
+class TestCleanPizelDimensions(unittest.TestCase):
+    def setUp(self):
+        self.pwd = get_installdir()
+        self.deidpath = os.path.abspath("%s/tests/resources/" % self.pwd)
+        print("\n######################START######################")
+
+    def tearDown(self):
+        print("\n######################END########################")
+
+    def test_has_burned_pixels_single_clean(self):
+        """Test that a DICOM has no burned pixels.
+
+        It uses a dummy DICOM FileDataset and a simple deid specification.
+        """
+        dicom_file = create_dummy_dicom()
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_multiple.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        expected_results = {
+            "flagged": False,
+            "results": [],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_detect(self):
+        """Test that a DICOM has burned pixels.
+
+        It uses a simple deid specification and a dummy DICOM FileDataset with an
+        SOPClassUID that matches that in the profile and a simple deid specification.
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_multiple.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Load the deid profile, which contains the SOPClassUID to check against and the
+        # coordinates to remove.
+        target_sop_class_uid = None
+        expected_coordinates = []
+        with open(deid_profile, "r") as f:
+            for line in f:
+                if "contains SOPClassUID" in line:
+                    target_sop_class_uid = line.split("contains SOPClassUID", 1)[
+                        1
+                    ].strip()
+                elif "coordinates" in line:
+                    expected_coordinates.append(
+                        [0, line.split("coordinates", 1)[1].strip()]
+                    )
+
+        dicom_file = create_dummy_dicom(sop_class_uid=target_sop_class_uid)
+
+        expected_results = {
+            "flagged": True,
+            "results": [
+                {
+                    "reason": f" SOPClassUID contains {target_sop_class_uid}",
+                    "group": "blacklist",
+                    "coordinates": expected_coordinates,
+                }
+            ],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_group_with_or_false(self):
+        """Test that _has_burned_pixels_single returns False when the Group With OR does
+        not match the first condition, even if one of the "or" group is true.
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Create a dummy DICOM FileDataset with a manufacturer that does NOT match the
+        # one in the "Group With OR" profile, and a SeriesDescription that does:
+        dicom_file = create_dummy_dicom(
+            manufacturer="dummy_manufacturer", series_description="flag me now"
+        )
+
+        expected_results = {
+            "flagged": False,
+            "results": [],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_group_with_or_true(self):
+        """Test that _has_burned_pixels_single returns True when the Group With OR does
+        match the first condition and one in the "OR" group.
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Load the deid profile to find the coordinates we expect to find in the results
+        expected_coordinates = []
+        with open(deid_profile, "r") as f:
+            for line in f:
+                if "coordinates" in line:
+                    expected_coordinates.append(
+                        [0, line.split("coordinates", 1)[1].strip()]
+                    )
+                    # just take the first one for this test
+                    break
+
+        # Create a dummy DICOM FileDataset with a manufacturer and SeriesDescription DO
+        # match those in the "Group With OR" profile:
+        dicom_file = create_dummy_dicom(
+            manufacturer="foo", series_description="flag me now"
+        )
+
+        expected_results = {
+            "flagged": True,
+            "results": [
+                {
+                    "reason": (
+                        "and Manufacturer contains foo ManufacturerModelName contains bar "
+                        "or SeriesDescription contains flag me"
+                    ),
+                    "group": "graylist",
+                    "coordinates": expected_coordinates,
+                }
+            ],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_value_with_or_false(self):
+        """Test that _has_burned_pixels_single returns False when the Value With OR does
+        not match the condition with the OR ("|").
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Create a dummy DICOM FileDataset with a manufacturer that does NOT match any
+        # of those in "Value With OR" profile, and a SeriesDescription that does:
+        dicom_file = create_dummy_dicom(
+            manufacturer="dummy_manufacturer", series_description="bamboo"
+        )
+
+        expected_results = {
+            "flagged": False,
+            "results": [],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_value_with_or_true(self):
+        """Test that _has_burned_pixels_single returns True when the Value With OR does
+        match one of the values in the first condition and also matches the second
+        condition.
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Load the deid profile to find the coordinates we expect to find in the results
+        expected_coordinates = []
+        with open(deid_profile, "r") as f:
+            skip_coordinates = False
+            for line in f:
+                # Skip the lines between "LABEL Group With OR" and "LABEL Value With OR"
+                if "LABEL Groups With OR" in line:
+                    skip_coordinates = True
+                    continue
+                if "LABEL Value With OR" in line:
+                    skip_coordinates = False
+                    continue
+                if "coordinates" in line and not skip_coordinates:
+                    expected_coordinates.append(
+                        [0, line.split("coordinates", 1)[1].strip()]
+                    )
+                    # just take the first one for this test
+                    break
+
+        # Create a dummy DICOM FileDataset with a manufacturer and SeriesDescription DO
+        # match those in the "Group With OR" profile:
+        dicom_file = create_dummy_dicom(manufacturer="foo", series_description="bamboo")
+
+        expected_results = {
+            "flagged": True,
+            "results": [
+                {
+                    "reason": (
+                        "and Manufacturer contains foo|bar|baz SeriesDescription contains "
+                        "bam"
+                    ),
+                    "group": "graylist",
+                    "coordinates": expected_coordinates,
+                }
+            ],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    def test_has_burned_pixels_single_value_with_and_false(self):
+        """Test that _has_burned_pixels_single returns False when the Value With AND
+        does not match the condition with the OR ("+").
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Create a dummy DICOM FileDataset with a manufacturer that does NOT match any
+        # of those in "Value With AND" profile, and a SeriesDescription that does:
+        dicom_file = create_dummy_dicom(manufacturer="foo", image_type=["ORIGINAL"])
+
+        expected_results = {
+            "flagged": False,
+            "results": [],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+    @unittest.skip(
+        reason="""I think dicom.contains() doesn't behave as expected:
+
+        If "contains ImageType DERIVED+SECONDARY" is in the deid profile, I think the
+        expected behavior is that ImageType must contain both "DERIVED" and "SECONDARY"
+        for the condition to be True. However, dicom.contains() returns False when both
+        elements are present in the ImageType list.
+        """
+    )
+    def test_has_burned_pixels_single_value_with_and_true(self):
+        """Test that _has_burned_pixels_single returns True when the Value With AND does
+        match one of the values in the first condition and also matches the second
+        condition.
+        """
+        deid_profile = os.path.join(self.deidpath, "remove_coordinates_groups.dicom")
+        deid = DeidRecipe(deid_profile)
+
+        # Load the deid profile to find the coordinates we expect to find in the results
+        expected_coordinates = []
+        with open(deid_profile, "r") as f:
+            skip_coordinates = False
+            for line in f:
+                # Skip the lines between "LABEL Group With OR" and "LABEL Value With OR"
+                if "LABEL Groups With OR" in line:
+                    skip_coordinates = True
+                    continue
+                if "LABEL Value With AND" in line:
+                    skip_coordinates = False
+                    continue
+                if "coordinates" in line and not skip_coordinates:
+                    expected_coordinates.append(
+                        [0, line.split("coordinates", 1)[1].strip()]
+                    )
+                    # just take the first one for this test
+                    break
+
+        # Create a dummy DICOM FileDataset with a manufacturer and SeriesDescription DO
+        # match those in the "Group With OR" profile:
+        dicom_file = create_dummy_dicom(
+            manufacturer="foo", image_type=["DERIVED", "SECONDARY", "IGNORED"]
+        )
+
+        expected_results = {
+            "flagged": True,
+            "results": [
+                {
+                    "reason": (
+                        "and Manufacturer contains foo ImageType contains DERIVED+SECONDARY"
+                    ),
+                    "group": "graylist",
+                    "coordinates": expected_coordinates,
+                }
+            ],
+        }
+
+        results = _has_burned_pixels_single(dicom_file, force=False, deid=deid)
+
+        assert results == expected_results
+
+        os.remove(dicom_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2025, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: #278

Fixes a bug in the logic of group evaluation in `_has_burned_pixels_single`.

It also adds unit tests for the method.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

There is a profile in the `deid.dicom` file which [includes](https://github.com/pydicom/deid/blob/master/deid/data/deid.dicom#L778):

```
+ contains ImageType DERIVED+SECONDARY+SCREEN SAVE
```

I think the expected behavior is that this group evaluates to `True` if all `"DERIVED"`, `"SECONDARY"` and `"SCREEN SAVE"` are elements of the `ImageType`. Currently, the logic of [`deid.dicom.filter.compareBase()`](https://github.com/pydicom/deid/blob/master/deid/dicom/filter.py#L175) does not behave that way.

It ends up calling `re.search("derived+secondary+screen save", <ImageType value>)`. `"derived+secondary+screen save"` is not a regex, so it fails, even if those desired values are all present in the `ImageType` of the image.
