### PR TITLE
bug: fixed keep remove action interaction issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Fix tag specification for KEEP action [#281](https://github.com/pydicom/deid/pull/281) (0.4.4)
 - Fix logic in evaluating flags for groups containing OR (`||`) [#278](https://github.com/pydicom/deid/pull/279) (0.4.3)
 - Fix incorrect assignment of deeply-nested tags to top-level tags [#277](https://github.com/pydicom/deid/pull/277) (0.4.2)
 - `deid` client saves cleaned dicoms when requested [#276](https://github.com/pydicom/deid/pull/276) (0.4.1)

--- a/deid/config/utils.py
+++ b/deid/config/utils.py
@@ -378,8 +378,8 @@ def parse_member(members, operator=None):
         member = members.pop(0).strip()
 
         # Find the first || or +
-        match_or = re.search("\|\|", member)  # noqa
-        match_and = re.search("\+", member)  # noqa
+        match_or = re.search(r"\|\|", member)  # noqa
+        match_and = re.search(r"\+", member)  # noqa
 
         if match_or is not None:
             operator = "||"

--- a/deid/dicom/parser.py
+++ b/deid/dicom/parser.py
@@ -289,11 +289,13 @@ class DicomParser:
         """
         keeps = []
         if self.recipe.deid is not None:
-            keeps = [
-                action.get("field")
-                for action in self.recipe.get_actions(action="KEEP")
-                if action and action.get("field")
-            ]
+            for action in self.recipe.get_actions(action="KEEP"):
+                if action and action.get("field"):
+                    fields = expand_field_expression(
+                        field=action.get("field"), dicom=self.dicom
+                    )
+                    # keys are in the format "(1234,5678)"
+                    keeps.extend(fields.keys())
         return keeps
 
     @property

--- a/deid/tests/test_action_interaction.py
+++ b/deid/tests/test_action_interaction.py
@@ -979,7 +979,7 @@ class TestRuleInteractions(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
-    def test_keep_remove_should_be_original_value(self):
+    def test_keep_remove_should_be_original_value_1(self):
         """RECIPE RULE
         KEEP StudyDate
         REMOVE StudyDate
@@ -989,6 +989,162 @@ class TestRuleInteractions(unittest.TestCase):
         dicom_file = get_file(self.dataset)
 
         field = "Manufacturer"
+
+        action1 = "KEEP"
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile[field].value
+        valueexpected = currentValue
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(valueexpected, outputfile[field].value)
+
+    def test_keep_remove_should_be_original_value_2(self):
+        """RECIPE RULE
+        KEEP startswith:Manu
+        REMOVE startswith:Manu
+        """
+
+        print("Test KEEP/REMOVE Interaction")
+        dicom_file = get_file(self.dataset)
+
+        field = "startswith:Manu"
+
+        action1 = "KEEP"
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile["Manufacturer"].value
+        valueexpected = currentValue
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(valueexpected, outputfile["Manufacturer"].value)
+
+    def test_keep_remove_single_standard_tag_should_be_original_value_1(self):
+        """RECIPE RULE
+        KEEP 00100010
+        REMOVE 00100010
+        """
+
+        print("Test KEEP/REMOVE Interaction")
+        dicom_file = get_file(self.dataset)
+
+        field = "00100010"
+
+        action1 = "KEEP"
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile[field].value
+        valueexpected = currentValue
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(valueexpected, outputfile[field].value)
+
+    def test_keep_remove_single_standard_tag_should_be_original_value_2(self):
+        """RECIPE RULE
+        KEEP (0010,0010)
+        REMOVE (0010,0010)
+        """
+
+        print("Test KEEP/REMOVE Interaction")
+        dicom_file = get_file(self.dataset)
+
+        field = "(0010,0010)"
+
+        action1 = "KEEP"
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile["00100010"].value
+        valueexpected = currentValue
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(valueexpected, outputfile["00100010"].value)
+
+    def test_keep_remove_single_private_tag_should_be_original_value(self):
+        """RECIPE RULE
+        KEEP 0033101E
+        REMOVE 0033101E
+        """
+
+        print("Test KEEP/REMOVE Interaction")
+        dicom_file = get_file(self.dataset)
+
+        field = "0033101E"
 
         action1 = "KEEP"
         action2 = "REMOVE"

--- a/deid/tests/test_remove_action.py
+++ b/deid/tests/test_remove_action.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from deid.data import get_dataset
+from deid.dicom import replace_identifiers, utils
+from deid.tests.common import create_recipe, get_file
+from deid.utils import get_installdir
+
+global generate_uid
+
+
+class TestRemoveAction(unittest.TestCase):
+    def setUp(self):
+        self.pwd = get_installdir()
+        self.deid = os.path.abspath("%s/../examples/deid/deid.dicom" % self.pwd)
+        self.dataset = get_dataset("humans")
+        self.tmpdir = tempfile.mkdtemp()
+        print("\n######################START######################")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        print("\n######################END########################")
+
+    def run_remove_single_tag_fieldtest(self, Field):
+        print(f"Test REMOVE standard tags in format {Field}")
+        dicom_file = get_file(self.dataset)
+
+        actions = [
+            {"action": "REMOVE", "field": Field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile["00100010"].value
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        with self.assertRaises(KeyError):
+            _ = outputfile["00100010"].value
+
+    def test_remove_standard_tags_1(self):
+        self.run_remove_single_tag_fieldtest(
+            "(0010,0010)"
+        )  # PatientName in DICOM format
+
+    def test_remove_standard_tags_2(self):
+        self.run_remove_single_tag_fieldtest("00100010")  # PatientName in hex format
+
+    def test_remove_standard_tags_3(self):
+        self.run_remove_single_tag_fieldtest(
+            "PatientName"
+        )  # PatientName in keyword format
+
+    def test_remove_standard_field_4(self):
+        self.run_remove_single_tag_fieldtest(
+            "startswith:PatientN"
+        )  # PatientName in startswith: format
+
+    def test_remove_single_private_tag_field(self):
+        """RECIPE RULE
+        REMOVE 0033101E
+        """
+        print("Test REMOVE private tag in format 0033101E")
+        dicom_file = get_file(self.dataset)
+
+        Field = "0033101E"  # Private tag in hex format
+        actions = [
+            {"action": "REMOVE", "field": Field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile[Field].value
+
+        self.assertNotEqual(None, currentValue)
+        self.assertNotEqual("", currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+        outputfile = utils.dcmread(result[0])
+
+        self.assertEqual(1, len(result))
+        with self.assertRaises(KeyError):
+            _ = outputfile[Field].value
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2025, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
# Description

Fix tag specification for KEEP action

KEEP action only worked with tag keyword (PatientName), It did not even recognize stripped tag (00100010) or any expanders.

This was due to that the skip list internally assumed to contain tag keyword (PatientName) or parentheses-enclosed comma-separated group&value ((0010,0010)) - see [here](https://github.com/pydicom/deid/blob/fa4731f79d7002d51e31cbec6f2586d87afb479d/deid/dicom/fields.py#L282-L283) - and the KEEP action's field specification strings were directly added to the skip list (without any normalization or expansion).

This commit fixes the KEEP action so that it accepts the same field specifications as all the other actions, which can contain tag name, keyword, stripped tag, expanders, or parentheses-enclosed comma-separated tag.

Parentheses-enclosed comma-separated tag format, such as (0010,0010) is added, because it is already used [here](https://github.com/pydicom/deid/blob/fa4731f79d7002d51e31cbec6f2586d87afb479d/deid/dicom/fields.py#L282-L283), and it is consistent with the planned (2121,"My Private Creator",34) format for private tags (see https://github.com/pydicom/deid/issues/280).

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project