### PR TITLE
bug: Fix REMOVE action to respect REPLACE or JITTER priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Fix REMOVE action to respect REPLACE or JITTER priority [#283](https://github.com/pydicom/deid/pull/283) (0.4.6)
 - Add enhanced private tag syntax support [#282](https://github.com/pydicom/deid/pull/282) (0.4.5)
 - Fix tag specification for KEEP action [#281](https://github.com/pydicom/deid/pull/281) (0.4.4)
 - Fix logic in evaluating flags for groups containing OR (`||`) [#278](https://github.com/pydicom/deid/pull/279) (0.4.3)

--- a/deid/tests/test_action_interaction.py
+++ b/deid/tests/test_action_interaction.py
@@ -1508,13 +1508,13 @@ class TestRuleInteractions(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual(valueexpected, outputfile[field].value)
 
-    def test_replace_remove_should_be_replace_value(self):
+    def test_replace_remove_should_be_replace_value_1(self):
         """RECIPE RULE
         REPLACE StudyDate 20221128
         REMOVE StudyDate
         """
 
-        print("Test REPLACE/REMOVE Interaction")
+        print("Test REPLACE/REMOVE Interaction with StudyDate field")
         dicom_file = get_file(self.dataset)
 
         field = "StudyDate"
@@ -1546,6 +1546,81 @@ class TestRuleInteractions(unittest.TestCase):
         outputfile = utils.dcmread(result[0])
         self.assertEqual(1, len(result))
         self.assertEqual(value1, outputfile[field].value)
+
+    def test_replace_remove_should_be_replace_value_2(self):
+        """RECIPE RULE
+        REPLACE startswith:StudyDat 20221128
+        REMOVE startswith:StudyDat
+        """
+
+        print("Test REPLACE/REMOVE Interaction with startswith:StudyDat field")
+        dicom_file = get_file(self.dataset)
+
+        field = "startswith:StudyDat"
+
+        action1 = "REPLACE"
+        value1 = "20221128"
+
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field, "value": value1},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile["StudyDate"].value
+        self.assertNotEqual(value1, currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(value1, outputfile["StudyDate"].value)
+
+    def test_replace_remove_should_be_replace_value_3(self):
+        """RECIPE RULE
+        REPLACE (0033,"MITRA OBJECT UTF8 ATTRIBUTES 1.0",1E) Hello
+        REMOVE (0033,"MITRA OBJECT UTF8 ATTRIBUTES 1.0",1E)
+        """
+
+        print("Test REPLACE/REMOVE Interaction with private creator syntax")
+        dicom_file = get_file(self.dataset)
+
+        field = '(0033,"MITRA OBJECT UTF8 ATTRIBUTES 1.0",1E)'
+
+        action1 = "REPLACE"
+        value1 = "Hello"
+        action2 = "REMOVE"
+
+        actions = [
+            {"action": action1, "field": field, "value": value1},
+            {"action": action2, "field": field},
+        ]
+        recipe = create_recipe(actions)
+
+        inputfile = utils.dcmread(dicom_file)
+        currentValue = inputfile["0033101E"].value
+        self.assertNotEqual(value1, currentValue)
+
+        result = replace_identifiers(
+            dicom_files=dicom_file,
+            deid=recipe,
+            save=True,
+            remove_private=False,
+            strip_sequences=False,
+        )
+
+        outputfile = utils.dcmread(result[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual(value1, outputfile["0033101E"].value)
 
     def test_remove_add_should_be_add_value(self):
         """RECIPE RULE

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2025, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
 Fix REMOVE action to respect REPLACE or JITTER priority

- Prevents `REMOVE` from deleting fields marked for later `REPLACE` or `JITTER` actions.
- Fixes issues where `REMOVE` would incorrectly delete fields that should be modified later, ensuring correct de-identification workflows and recipe compliance.
- Previously, only exact string matches (e.g., field names or keywords) in the `REMOVE` action would be excluded if they appeared in the `REPLACE`/`JITTER` list.
- Now, the code uses `expand_field_expression` for robust, format-agnostic matching between excluded fields (from the recipe) and internal field representations.
- All field identifier formats are normalized using `expand_field_expression`, so exclusions work regardless of how the field is specified in the recipe.

Supported field formats for exclusion now include:
- Standard tag string: `(0008,0020)`
- Expander syntax: `startswith:StudyDa`
- Private creator syntax: `(0033,"MITRA OBJECT UTF8 ATTRIBUTES 1.0",1E)`

It is now possible to safely use any supported field format in `REPLACE`, `JITTER`, and `REMOVE` actions, and the exclusion logic will work as expected, regardless of the identifier format.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project