### PR TITLE
Allow saving with a compressed transfer syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+- Allow saving with a compressed transfer syntax [#290](https://github.com/pydicom/deid/pull/290) (0.4.7)
+- Improve performance of header deid with caching and lookup tables [#289](https://github.com/pydicom/deid/pull/289)
 - Fix REMOVE action to respect REPLACE or JITTER priority [#283](https://github.com/pydicom/deid/pull/283) (0.4.6)
 - Add enhanced private tag syntax support [#282](https://github.com/pydicom/deid/pull/282) (0.4.5)
 - Fix tag specification for KEEP action [#281](https://github.com/pydicom/deid/pull/281) (0.4.4)

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -234,7 +234,11 @@ class DicomCleaner:
             bot.warning("use detect() --> clean() before saving is possible.")
 
     def save_dicom(
-        self, output_folder=None, image_type="cleaned", preserve_compression=False
+        self,
+        output_folder=None,
+        image_type="cleaned",
+        preserve_compression=False,
+        compression=None,
     ):
         """
         Save a cleaned dicom to disk.
@@ -258,6 +262,14 @@ class DicomCleaner:
                     bot.warning(
                         "Could not recompress dicom with %s, saving uncompressed."
                         % original_transfer_syntax
+                    )
+            elif compression is not None:
+                try:
+                    dicom.compress(compression)
+                except NotImplementedError:
+                    bot.warning(
+                        "Could not recompress dicom with %s, saving uncompressed."
+                        % compression
                     )
 
             dicom.save_as(dicom_name)

--- a/deid/dicom/pixels/clean.py
+++ b/deid/dicom/pixels/clean.py
@@ -246,6 +246,12 @@ class DicomCleaner:
         We expose an option to save an original (change image_type to "original"
         to be consistent, although this is not incredibly useful given it would
         duplicate the original data.
+
+        Additional options:
+        - `preserve_compression`: if the original dicom was compressed, attempt
+           to use the same compression when saving back out to disk.
+        - `compression`: if provided, attempt to use this compression when
+           saving back out to disk.
         """
         # Having clean also means has dicom image
         if hasattr(self, image_type):

--- a/deid/tests/test_clean.py
+++ b/deid/tests/test_clean.py
@@ -244,20 +244,15 @@ class TestClean(unittest.TestCase):
 
         client.clean()
         # Explicitly save as a RLELossless compressed transfer syntax
-        cleanedfile = client.save_dicom(compression=RLELossless)
-
-        outputfile = utils.dcmread(cleanedfile)
-        outputpixels = outputfile.pixel_array
-
-        # Assert the pixel values have changed after compression
-        inputfile = utils.dcmread(dicom_file)
-        inputpixels = inputfile.pixel_array
-        compare = inputpixels == outputpixels
-        self.assertFalse(compare.all())
+        uncompressed = client.save_dicom()
+        uncompressed_file = utils.dcmread(uncompressed)
+        # Explicitly save as a RLELossless compressed transfer syntax
+        compressed = client.save_dicom(compression=RLELossless)
+        compressed_file = utils.dcmread(compressed)
 
         # Assert the transfer syntax has changed
-        self.assertEqual(outputfile.file_meta.TransferSyntaxUID, RLELossless)
-        self.assertNotEqual(inputfile.file_meta.TransferSyntaxUID, RLELossless)
+        self.assertEqual(compressed_file.file_meta.TransferSyntaxUID, RLELossless)
+        self.assertNotEqual(uncompressed_file.file_meta.TransferSyntaxUID, RLELossless)
 
 
 if __name__ == "__main__":

--- a/deid/version.py
+++ b/deid/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2016-2025, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "deid"


### PR DESCRIPTION
# Description

Related issues: None

Currently, `deid` only saves images in decompressed format. This can lead to some surprising balloons in disk usage when you expand compressed DICOM images. In my particular use case, I noticed this when running `deid` in Pyodide due to a sharp increase in RAM usage-- this correlated to saving DICOM in decompressed format to the memFS filesystem, forcing the WASM memory allocation to increase substantially.

This PR introduces two new options to the `save_dicom` function-- `preserve_compression`, which will attempt to save the dataset back into the same compression format it had originally; and `compression`, which allows the user to specify a particular compression transfer syntax they would like to use for the output.

I understand that adding additional kwargs is not always desirable-- I think the `compression` kwarg is the most critical for my own use case, so if you would prefer to toss `preserve_compression` I can revert that one.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project


# Open questions

Questions that require more discussion or to be addressed in future development: None
